### PR TITLE
Use XDG directories

### DIFF
--- a/configure
+++ b/configure
@@ -7895,6 +7895,35 @@ fi
 
 
 
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libxdg-basedir" >&5
+$as_echo_n "checking for libxdg-basedir... " >&6; }
+  if test $PKG_CONFIG != no && $PKG_CONFIG --exists libxdg-basedir; then
+    XDG_BASEDIR_CFLAGS="`$PKG_CONFIG --cflags libxdg-basedir`"
+    XDG_BASEDIR_LIBS="`$PKG_CONFIG --libs libxdg-basedir`"
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+$as_echo "ok" >&6; }
+
+  CPPFLAGS="$CPPFLAGS $XDG_BASEDIR_CFLAGS"
+  LIBS="$LIBS $XDG_BASEDIR_LIBS"
+  ac_fn_cxx_check_header_mongrel "$LINENO" "basedir.h" "ac_cv_header_basedir_h" "$ac_includes_default"
+if test "x$ac_cv_header_basedir_h" = xyes; then :
+
+else
+  as_fn_error $? "Unable to find libxdg-basedir" "$LINENO" 5
+fi
+
+
+
+  else
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+  as_fn_error $? "Unable to find libxdg-basedir" "$LINENO" 5
+
+  fi
+
+
 ac_config_files="$ac_config_files Makefile src/Makefile"
 
 cat >confcache <<\_ACEOF

--- a/configure
+++ b/configure
@@ -7587,6 +7587,8 @@ fi
     if test $XFT_CONFIG != no; then
       X_LIBS="`$XFT_CONFIG --libs` $X_LIBS"
       CPPFLAGS="$CPPFLAGS `$XFT_CONFIG --cflags`"
+    else
+      as_fn_error $? "Unable to find Xft or FreeType" "$LINENO" 5
     fi
 
   fi
@@ -9177,7 +9179,7 @@ fi
 
 echo "Configuration:
 
-  Rxvt version:               $VERSION : $DATE
+  raxvt version:              $VERSION : $DATE
   Source code location:       $srcdir
   Install path:               ${prefix}/bin
   Compiler:                   $CXX

--- a/configure.ac
+++ b/configure.ac
@@ -716,6 +716,13 @@ AC_SUBST(PERL)
 AC_SUBST(IF_PERL)
 AC_SUBST(PERL_O)
 
+RXVT_CHECK_MODULES([XDG_BASEDIR], [libxdg-basedir], [
+  CPPFLAGS="$CPPFLAGS $XDG_BASEDIR_CFLAGS"
+  LIBS="$LIBS $XDG_BASEDIR_LIBS"
+  AC_CHECK_HEADER(basedir.h,,[AC_MSG_ERROR([Unable to find libxdg-basedir])])
+], [
+  AC_MSG_ERROR([Unable to find libxdg-basedir])
+])
 
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -570,6 +570,8 @@ if test x$rxvt_have_xrender = xyes; then
     if test $XFT_CONFIG != no; then
       X_LIBS="`$XFT_CONFIG --libs` $X_LIBS"
       CPPFLAGS="$CPPFLAGS `$XFT_CONFIG --cflags`"
+    else
+      AC_MSG_ERROR([Unable to find Xft or FreeType])
     fi
   ])
 
@@ -720,7 +722,7 @@ AC_OUTPUT
 
 echo "Configuration:
 
-  Rxvt version:               $VERSION : $DATE
+  raxvt version:              $VERSION : $DATE
   Source code location:       $srcdir
   Install path:               ${prefix}/bin
   Compiler:                   $CXX

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -140,7 +140,8 @@ int rxvt_composite_vec::expand (unicode_t c, wchar_t *r)
 }
 #endif
 
-rxvt_term::rxvt_term ()
+rxvt_term::rxvt_term()
+  : xdg_handle_initialized(false)
 {
 #ifdef CURSOR_BLINK
   cursor_blink_ev.set     <rxvt_term, &rxvt_term::cursor_blink_cb> (this); cursor_blink_ev.set (0., CURSOR_BLINK_INTERVAL);
@@ -184,6 +185,11 @@ rxvt_term::rxvt_term ()
 #ifdef KEYSYM_RESOURCE
   keyboard = new keyboard_manager;
 #endif
+
+  if (xdgInitHandle(&xdg_handle))
+  {
+    xdg_handle_initialized = true;
+  }
 }
 
 // clean up the most important stuff, do *not* call x or free mem etc.
@@ -277,6 +283,11 @@ rxvt_term::~rxvt_term ()
 #ifndef NO_RESOURCES
   XrmDestroyDatabase (option_db);
 #endif
+
+  if (xdg_handle_initialized)
+  {
+    xdgWipeHandle(&xdg_handle);
+  }
 
   SET_R ((rxvt_term *)0);
 }

--- a/src/rxvt.h
+++ b/src/rxvt.h
@@ -7,10 +7,12 @@
 #include <cstdarg>
 #include <cstdlib>
 #include <cstdint>
-#include <sys/types.h>
-#include <unistd.h>
 #include <cstring>
 #include <cassert>
+#include <string>
+
+#include <sys/types.h>
+#include <unistd.h>
 #ifdef HAVE_SYS_IOCTL_H
 #include <sys/ioctl.h>
 #endif

--- a/src/rxvt.h
+++ b/src/rxvt.h
@@ -30,6 +30,7 @@ extern "C" {
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xresource.h>
+#include <basedir.h>
 }
 
 #if UNICODE_3
@@ -1140,6 +1141,9 @@ struct rxvt_term : zero_initialized, rxvt_vars, rxvt_screen
   uint32_t        rgb24_color[RGB24_CUBE_SIZE];   // the 24-bit color value
   uint16_t        rgb24_seqno[RGB24_CUBE_SIZE];   // which one is older?
   uint16_t        rgb24_sequence;
+
+  xdgHandle xdg_handle;
+  bool xdg_handle_initialized;
 
   static vector<rxvt_term *> termlist; // a vector of all running rxvt_term's
 

--- a/src/rxvtdaemon.cpp
+++ b/src/rxvtdaemon.cpp
@@ -23,41 +23,41 @@
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>
-
 #include <cinttypes>
-#include <unistd.h>
 #include <cerrno>
+
+#include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 
+#include <basedir.h>
+
 #include "rxvtdaemon.h"
 
-char *rxvt_connection::unix_sockname ()
+char* rxvt_connection::unix_sockname()
 {
-  char name[PATH_MAX];
-  char *path = getenv ("RXVT_SOCKET");
+  const char* path = std::getenv("RAXVT_SOCKET");
 
   if (!path)
+  {
+    const char* runtime_dir = xdgRuntimeDirectory(nullptr);
+    struct utsname u;
+    char buffer[PATH_MAX];
+
+    uname(&u);
+    if (runtime_dir)
     {
-      struct utsname u;
-      uname (&u);
-
-      path = getenv ("HOME");
-      if (!path)
-        path = "/tmp";
-
-      snprintf (name, PATH_MAX, "%s/.urxvt", path);
-      mkdir (name, 0777);
-
-      snprintf (name, PATH_MAX, "%s/.urxvt/urxvtd-%s",
-                path,
-                u.nodename);
-
-      path = name;
+      std::snprintf(buffer, PATH_MAX, "%s/raxvtd-%s", runtime_dir, u.nodename);
+      std::free(const_cast<char*>(runtime_dir));
+    } else {
+      std::snprintf(buffer, PATH_MAX, "/tmp/raxvtd-%s", u.nodename);
     }
 
-  return strdup (path);
+    return strdup(buffer);
+  }
+
+  return strdup(path);
 }
 
 void rxvt_connection::send (const char *data, int len)

--- a/src/rxvtutil.cpp
+++ b/src/rxvtutil.cpp
@@ -65,36 +65,3 @@ rxvt_temp_buf (int len)
 
   return temp_buf;
 }
-
-std::string
-get_config_directory()
-{
-  const char* xdg_config_home_dir = std::getenv("XDG_CONFIG_HOME");
-  std::string result;
-
-  if (!xdg_config_home_dir || !*xdg_config_home_dir)
-  {
-    const char* home_dir = std::getenv("HOME");
-
-    if (home_dir && *home_dir)
-    {
-      result += home_dir;
-      if (!result.empty() && result[result.length() - 1] != '/')
-      {
-        result += '/';
-      }
-    } else {
-      result += "./";
-    }
-    result += ".config/raxvt";
-  } else {
-    result += xdg_config_home_dir;
-    if (!result.empty() && result[result.length() - 1] != '/')
-    {
-      result += '/';
-    }
-    result += "raxvt";
-  }
-
-  return result;
-}

--- a/src/rxvtutil.h
+++ b/src/rxvtutil.h
@@ -3,7 +3,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <string>
 #include "ecb.h"
 #include "estl.h"
 
@@ -71,7 +70,5 @@ struct stringvec : simplevec<char *>
 };
 
 typedef estl::scoped_array<char> auto_str;
-
-std::string get_config_directory();
 
 #endif


### PR DESCRIPTION
Add [libxdg-basedir] into the project as dependency and use it's features to retrieve XDG compliant configuration and runtime directories for terminal configs and daemon sockets.

[libxdg-basedir]: https://github.com/devnev/libxdg-basedir