### PR TITLE
Use hash maps to store settings

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -441,16 +441,16 @@ rxvt_term::key_press (XKeyEvent &ev)
 
           // the XOpenIM manpage lies about hardcoding the locale
           // at the point of XOpenIM, so temporarily switch locales
-          if (rs[Rs_imLocale])
+          if (get_setting(Rs_imLocale))
           {
-            rxvt_set_locale(rs[Rs_imLocale]);
+            rxvt_set_locale(get_setting(Rs_imLocale));
           }
 
           // assume wchar_t == unicode or better
           len = XwcLookupString (Input_Context, &ev, wkbuf,
                                  KBUFSZ, &keysym, &status_return);
 
-          if (rs[Rs_imLocale])
+          if (get_setting(Rs_imLocale))
           {
             rxvt_set_locale(locale);
           }
@@ -514,12 +514,12 @@ rxvt_term::key_press (XKeyEvent &ev)
                     kbuf[1] = '\0';
                   }
                 else
-                  std::strcpy(kbuf, rs[Rs_backspace_key]);
+                  std::strcpy(kbuf, get_setting(Rs_backspace_key));
                 break;
 #endif
 #ifndef NO_DELETE_KEY
               case XK_Delete:
-                std::strcpy(kbuf, rs[Rs_delete_key]);
+                std::strcpy(kbuf, get_setting(Rs_delete_key));
                 break;
 #endif
               case XK_Tab:
@@ -845,7 +845,7 @@ rxvt_term::key_press (XKeyEvent &ev)
               iso14755buf = 0;
             }
         }
-      else if (option (Opt_iso14755) &&
+      else if (get_option(Opt_iso14755) &&
                ((ctrl && (keysym == XK_Shift_L || keysym == XK_Shift_R))
                 || (shft && (keysym == XK_Control_L || keysym == XK_Control_R))))
         if (!(iso14755buf & ISO_14755_STARTED))
@@ -926,7 +926,7 @@ rxvt_term::key_release (XKeyEvent &ev)
         if (iso14755buf & ISO_14755_51)
           commit_iso14755 ();
 #if ISO_14755
-        else if (option (Opt_iso14755_52) && iso14755buf & ISO_14755_STARTED)
+        else if (get_option(Opt_iso14755_52) && iso14755buf & ISO_14755_STARTED)
           {
             iso14755buf = ISO_14755_52; // iso14755 part 5.2: remember empty begin/end pair
 
@@ -1045,7 +1045,7 @@ rxvt_term::cursor_blink_reset ()
       want_refresh = 1;
     }
 
-  if (option (Opt_cursorBlink) || (priv_modes & PrivMode_BlinkingCursor))
+  if (get_option(Opt_cursorBlink) || (priv_modes & PrivMode_BlinkingCursor))
     cursor_blink_ev.again ();
   else
     cursor_blink_ev.stop ();
@@ -1217,7 +1217,7 @@ rxvt_term::pty_fill ()
     {
       pty_ev.stop ();
 
-      if (!option (Opt_hold))
+      if (!get_option(Opt_hold))
         destroy ();
     }
 
@@ -1249,7 +1249,7 @@ rxvt_term::pointer_unblank ()
 #ifdef POINTER_BLANK
   hidden_pointer = 0;
 
-  if (option (Opt_pointerBlank))
+  if (get_option(Opt_pointerBlank))
     pointer_ev.start (pointerBlankDelay);
 #endif
 }
@@ -1258,7 +1258,7 @@ rxvt_term::pointer_unblank ()
 void ecb_cold
 rxvt_term::pointer_blank ()
 {
-  if (!option (Opt_pointerBlank))
+  if (!get_option(Opt_pointerBlank))
     return;
 
   XDefineCursor (dpy, vt, display->blank_cursor);
@@ -1698,7 +1698,7 @@ rxvt_term::x_cb (XEvent &ev)
 #endif
 
 #if defined(POINTER_BLANK)
-  if (option (Opt_pointerBlank) && pointerBlankDelay > 0)
+  if (get_option(Opt_pointerBlank) && pointerBlankDelay > 0)
     {
       if (ev.type == MotionNotify
           || ev.type == ButtonPress
@@ -1747,18 +1747,18 @@ rxvt_term::focus_in ()
         }
 #endif
 #if CURSOR_BLINK
-      if (option (Opt_cursorBlink))
+      if (get_option(Opt_cursorBlink))
         cursor_blink_ev.again ();
 #endif
 #if OFF_FOCUS_FADING
-      if (rs[Rs_fade])
+      if (get_setting(Rs_fade))
         {
           pix_colors = pix_colors_focused;
           scr_recolor ();
         }
 #endif
 #if ENABLE_FRILLS
-      if (option (Opt_urgentOnBell))
+      if (get_option(Opt_urgentOnBell))
         set_urgency (0);
 
       if (priv_modes & PrivMode_FocusEvent)
@@ -1778,7 +1778,7 @@ rxvt_term::focus_out ()
       want_refresh = 1;
 
 #if ENABLE_FRILLS
-      if (option (Opt_urgentOnBell))
+      if (get_option(Opt_urgentOnBell))
         set_urgency (0);
 
       if (priv_modes & PrivMode_FocusEvent)
@@ -1798,13 +1798,13 @@ rxvt_term::focus_out ()
         XUnsetICFocus (Input_Context);
 #endif
 #if CURSOR_BLINK
-      if (option (Opt_cursorBlink))
+      if (get_option(Opt_cursorBlink))
         cursor_blink_ev.stop ();
 
       hidden_cursor = 0;
 #endif
 #if OFF_FOCUS_FADING
-      if (rs[Rs_fade])
+      if (get_setting(Rs_fade))
         {
           pix_colors = pix_colors_unfocused;
           scr_recolor ();
@@ -1819,14 +1819,14 @@ void ecb_cold
 rxvt_term::update_fade_color (unsigned int idx, bool first_time)
 {
 #if OFF_FOCUS_FADING
-  if (rs[Rs_fade])
+  if (get_setting(Rs_fade))
     {
       if (!first_time)
         pix_colors_focused [idx].free (this);
 
       rgba c;
       pix_colors [Color_fade].get (c);
-      pix_colors_focused [idx].fade (this, atoi (rs[Rs_fade]), pix_colors_unfocused [idx], c);
+      pix_colors_focused [idx].fade (this, atoi (get_setting(Rs_fade)), pix_colors_unfocused [idx], c);
     }
 #endif
 }
@@ -2193,7 +2193,7 @@ rxvt_term::button_release (XButtonEvent &ev)
 
               if (ev.state & ShiftMask)
                 lines = 1;
-              else if (option (Opt_mouseWheelScrollPage))
+              else if (get_option(Opt_mouseWheelScrollPage))
                 lines = nrow - 1;
               else
                 lines = 5;
@@ -2276,11 +2276,11 @@ rxvt_term::cmd_parse ()
 
                   refresh_count++;
 
-                  if (!option (Opt_jumpScroll) || refresh_count >= nrow - 1)
+                  if (!get_option(Opt_jumpScroll) || refresh_count >= nrow - 1)
                     {
                       refresh_count = 0;
 
-                      if (!option (Opt_skipScroll) || ev_time () > ev::now () + 1. / 60.)
+                      if (!get_option(Opt_skipScroll) || ev_time () > ev::now () + 1. / 60.)
                         {
                           refreshnow = true;
                           ch = NOCHAR;
@@ -2425,7 +2425,7 @@ rxvt_term::cmd_get8 () THROW ((class out_of_input))
 FILE * ecb_cold
 rxvt_term::popen_printer ()
 {
-  FILE *stream = popen (rs[Rs_print_pipe] ? rs[Rs_print_pipe] : PRINTPIPE, "w");
+  FILE *stream = popen (get_setting(Rs_print_pipe) ? get_setting(Rs_print_pipe) : PRINTPIPE, "w");
 
   if (stream == NULL)
     rxvt_warn ("can't open printer pipe, not printing.\n");
@@ -2517,9 +2517,9 @@ rxvt_term::process_nonprinting (unicode_t ch)
         process_escape_seq ();
         break;
       case C0_ENQ:	/* terminal Status */
-        if (rs[Rs_answerbackstring])
+        if (get_setting(Rs_answerbackstring))
         {
-          tt_write(rs[Rs_answerbackstring], std::strlen(rs[Rs_answerbackstring]));
+          tt_write(get_setting(Rs_answerbackstring), std::strlen(get_setting(Rs_answerbackstring)));
         } else {
           tt_write(VT100_ANS, std::strlen(VT100_ANS));
         }
@@ -2697,7 +2697,7 @@ rxvt_term::process_escape_seq ()
         /* kidnapped escape sequence: Should be 8.3.48 */
       case C1_ESA:		/* ESC G */
         // used by original rxvt for rob nations own graphics mode
-        if (cmd_getc () == 'Q' && option (Opt_insecure))
+        if (cmd_getc () == 'Q' && get_option(Opt_insecure))
           tt_printf ("\033G0\012");	/* query graphics - no graphics */
         break;
 
@@ -3013,8 +3013,8 @@ rxvt_term::process_csi_seq ()
               scr_report_position ();
               break;
             case 7:			/* unofficial extension */
-              if (option (Opt_insecure))
-                tt_printf ("%-.250s\012", rs[Rs_display_name]);
+              if (get_option(Opt_insecure))
+                tt_printf ("%-.250s\012", get_setting(Rs_display_name));
               break;
             case 8:			/* unofficial extension */
               process_xterm_seq (XTerm_title, RESNAME "-" VERSION, CHAR_ST);
@@ -3191,7 +3191,7 @@ rxvt_term::process_window_ops (const int *args, unsigned int nargs)
         {
           char *s;
           XGetIconName (dpy, parent, &s);
-          tt_printf ("\033]L%-.250s\234", option (Opt_insecure) && s ? s : "");	/* 8bit ST */
+          tt_printf ("\033]L%-.250s\234", get_option(Opt_insecure) && s ? s : "");	/* 8bit ST */
           XFree (s);
         }
         break;
@@ -3199,7 +3199,7 @@ rxvt_term::process_window_ops (const int *args, unsigned int nargs)
         {
           char *s;
           XFetchName (dpy, parent, &s);
-          tt_printf ("\033]l%-.250s\234", option (Opt_insecure) && s ? s : "");	/* 8bit ST */
+          tt_printf ("\033]l%-.250s\234", get_option(Opt_insecure) && s ? s : "");	/* 8bit ST */
           XFree (s);
         }
         break;
@@ -3456,7 +3456,7 @@ rxvt_term::process_xterm_seq (int op, char *str, char resp)
                 && actual_format == 8)
               str = (const char *)(value);
 
-            tt_printf ("\033]%d;%s%c", op, option (Opt_insecure) ? str : "", resp);
+            tt_printf ("\033]%d;%s%c", op, get_option(Opt_insecure) ? str : "", resp);
 
             XFree (value);
           }
@@ -3548,32 +3548,28 @@ rxvt_term::process_xterm_seq (int op, char *str, char resp)
       case URxvt_boldItalicFont:
 #endif
         if (query)
+        {
           tt_printf ("\33]%d;%-.250s%c", saveop,
-                     option (Opt_insecure) && fontset[op - URxvt_font]->fontdesc
+                     get_option(Opt_insecure) && fontset[op - URxvt_font]->fontdesc
                        ? fontset[op - URxvt_font]->fontdesc : "",
                      resp);
-        else
-          {
-            const char *&res = rs[Rs_font + (op - URxvt_font)];
-
-            res = strdup (str);
-            allocated.push_back ((void *)res);
-            set_fonts ();
-          }
+        } else {
+          set_fonts();
+        }
         break;
 
       case URxvt_version:
         if (query)
           tt_printf ("\33]%d;rxvt-unicode;%-.20s;%c;%c%c",
                      op,
-                     rs[Rs_name], VERSION[0], VERSION[2],
+                     get_setting(Rs_name), VERSION[0], VERSION[2],
                      resp);
         break;
 
 #if !ENABLE_MINIMAL
       case URxvt_locale:
         if (query)
-          tt_printf ("\33]%d;%-.250s%c", op, option (Opt_insecure) ? locale : "", resp);
+          tt_printf ("\33]%d;%-.250s%c", op, get_option(Opt_insecure) ? locale : "", resp);
         else
           {
             set_locale (str);
@@ -3731,13 +3727,13 @@ rxvt_term::process_terminal_mode (int mode, int priv ecb_unused, unsigned int na
         {
 #if ENABLE_STYLES
           case 1021:
-            set_option (Opt_intensityStyles, mode);
+            set_option(Opt_intensityStyles, mode);
 
             scr_touch (true);
             break;
 #endif
           case 1048:		/* alternative cursor save */
-            if (option (Opt_secondaryScreen))
+            if (get_option(Opt_secondaryScreen))
               if (mode == 0)
                 scr_cursor (RESTORE);
               else if (mode == 1)
@@ -3762,7 +3758,7 @@ rxvt_term::process_terminal_mode (int mode, int priv ecb_unused, unsigned int na
                 set_widthheight ((state ? 132 : 80) * fwidth, 24 * fheight);
               break;
             case 4:			/* smooth scrolling */
-              set_option (Opt_jumpScroll, !state);
+              set_option(Opt_jumpScroll, !state);
               break;
             case 5:			/* reverse video */
               scr_rvideo_mode (state);
@@ -3819,26 +3815,26 @@ rxvt_term::process_terminal_mode (int mode, int priv ecb_unused, unsigned int na
               vt_select_input ();
               break;
             case 1010:		/* scroll to bottom on TTY output inhibit */
-              set_option (Opt_scrollTtyOutput, !state);
+              set_option(Opt_scrollTtyOutput, !state);
               break;
             case 1011:		/* scroll to bottom on key press */
-              set_option (Opt_scrollTtyKeypress, state);
+              set_option(Opt_scrollTtyKeypress, state);
               break;
             case 1047:		/* secondary screen w/ clearing last */
-              if (option (Opt_secondaryScreen))
+              if (get_option(Opt_secondaryScreen))
                 if (!state)
                   scr_erase_screen (2);
 
               scr_change_screen (state);
               break;
             case 1049:		/* secondary screen w/ clearing first */
-              if (option (Opt_secondaryScreen))
+              if (get_option(Opt_secondaryScreen))
                 if (state)
                   scr_cursor (SAVE);
 
               scr_change_screen (state);
 
-              if (option (Opt_secondaryScreen))
+              if (get_option(Opt_secondaryScreen))
                 if (state)
                   scr_erase_screen (2);
                 else
@@ -4029,10 +4025,10 @@ rxvt_term::set_cursor_style (int style)
     style = 1;
 
   cursor_type = (style - 1) / 2;
-  set_option (Opt_cursorUnderline, cursor_type == 1);
+  set_option(Opt_cursorUnderline, cursor_type == 1);
 
 #ifdef CURSOR_BLINK
-  set_option (Opt_cursorBlink, style & 1);
+  set_option(Opt_cursorBlink, style & 1);
   cursor_blink_reset ();
 #endif
 
@@ -4068,7 +4064,7 @@ rxvt_term::tt_write_user_input (const char *data, unsigned int len)
   if (HOOK_INVOKE ((this, HOOK_TT_WRITE, DT_STR_LEN, data, len, DT_END)))
     return;
 
-  if (option (Opt_scrollTtyKeypress))
+  if (get_option(Opt_scrollTtyKeypress))
     if (view_start)
       {
         view_start = 0;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -502,17 +502,17 @@ rxvt_term::init_vars ()
 
   oldcursor.row = oldcursor.col = -1;
 
-  set_option (Opt_scrollBar);
-  set_option (Opt_scrollTtyOutput);
-  set_option (Opt_jumpScroll);
-  set_option (Opt_skipScroll);
-  set_option (Opt_secondaryScreen);
-  set_option (Opt_secondaryScroll);
-  set_option (Opt_pastableTabs);
-  set_option (Opt_intensityStyles);
-  set_option (Opt_iso14755);
-  set_option (Opt_iso14755_52);
-  set_option (Opt_buffered);
+  set_option(Opt_scrollBar, true);
+  set_option(Opt_scrollTtyOutput, true);
+  set_option(Opt_jumpScroll, true);
+  set_option(Opt_skipScroll, true);
+  set_option(Opt_secondaryScreen, true);
+  set_option(Opt_secondaryScroll, true);
+  set_option(Opt_pastableTabs, true);
+  set_option(Opt_intensityStyles, true);
+  set_option(Opt_iso14755, true);
+  set_option(Opt_iso14755_52, true);
+  set_option(Opt_buffered, true);
 }
 
 #if ENABLE_PERL
@@ -530,19 +530,25 @@ rxvt_term::init_resources (int argc, const char *const *argv)
   int i;
   const char **cmd_argv;
 
-  rs[Rs_name] = rxvt_basename (argv[0]);
+  set_setting(Rs_name, rxvt_basename(argv[0]));
 
   /*
    * Open display, get options/resources and create the window
    */
+  {
+    const char* display_name = std::getenv("DISPLAY");
 
-  if ((rs[Rs_display_name] = getenv ("DISPLAY")) == NULL)
-    rs[Rs_display_name] = ":0";
+    if (!display_name)
+    {
+      display_name = ":0";
+    }
+    set_setting(Rs_display_name, display_name);
+  }
 
   cmd_argv = get_options (argc, argv);
 
-  if (!(display = displays.get (rs[Rs_display_name])))
-    rxvt_fatal ("can't open display %s, aborting.\n", rs[Rs_display_name]);
+  if (!(display = displays.get (get_setting(Rs_display_name))))
+    rxvt_fatal ("can't open display %s, aborting.\n", get_setting(Rs_display_name));
 
   // using a local pointer decreases code size a lot
   xa = display->xa;
@@ -551,23 +557,21 @@ rxvt_term::init_resources (int argc, const char *const *argv)
   load_settings();
 
 #if ENABLE_FRILLS
-  if (rs[Rs_visual])
-    select_visual (strtol (rs[Rs_visual], 0, 0));
-  else if (rs[Rs_depth])
-    select_depth (strtol (rs[Rs_depth], 0, 0));
+  if (get_setting(Rs_visual))
+    select_visual (strtol (get_setting(Rs_visual), 0, 0));
+  else if (get_setting(Rs_depth))
+    select_depth (strtol (get_setting(Rs_depth), 0, 0));
 #endif
 
-  for (int i = NUM_RESOURCES; i--; )
-    if (rs [i] == resval_undef)
-      rs [i] = 0;
-
 #if ENABLE_PERL
-  if (!rs[Rs_perl_ext_1])
-    rs[Rs_perl_ext_1] = "default";
+  if (!get_setting(Rs_perl_ext_1))
+  {
+    set_setting(Rs_perl_ext_1, "default");
+  }
 
-  if ((rs[Rs_perl_ext_1] && *rs[Rs_perl_ext_1])
-      || (rs[Rs_perl_ext_2] && *rs[Rs_perl_ext_2])
-      || (rs[Rs_perl_eval] && *rs[Rs_perl_eval]))
+  if ((get_setting(Rs_perl_ext_1) && *get_setting(Rs_perl_ext_1))
+      || (get_setting(Rs_perl_ext_2) && *get_setting(Rs_perl_ext_2))
+      || (get_setting(Rs_perl_eval) && *get_setting(Rs_perl_eval)))
     {
       rxvt_perl.init (this);
       enumerate_resources (rxvt_perl_parse_resource);
@@ -583,100 +587,126 @@ rxvt_term::init_resources (int argc, const char *const *argv)
    * set any defaults not already set
    */
   if (cmd_argv && cmd_argv[0])
+  {
+    if (!get_setting(Rs_title))
     {
-      if (!rs[Rs_title])
-        rs[Rs_title] = rxvt_basename (cmd_argv[0]);
-
-      if (!rs[Rs_iconName])
-        rs[Rs_iconName] = rs[Rs_title];
-    }
-  else
-    {
-      if (!rs[Rs_title])
-        rs[Rs_title] = rs[Rs_name];
-
-      if (!rs[Rs_iconName])
-        rs[Rs_iconName] = rs[Rs_name];
+      set_setting(Rs_title, rxvt_basename(cmd_argv[0]));
     }
 
-  if (rs[Rs_saveLines] && (i = atoi (rs[Rs_saveLines])) >= 0)
+    if (!get_setting(Rs_iconName))
+    {
+      set_setting(Rs_iconName, get_setting(Rs_title));
+    }
+  } else {
+    if (!get_setting(Rs_title))
+    {
+      set_setting(Rs_title, get_setting(Rs_name));
+    }
+
+    if (!get_setting(Rs_iconName))
+    {
+      set_setting(Rs_iconName, get_setting(Rs_name));
+    }
+  }
+
+  if (get_setting(Rs_saveLines) && (i = atoi (get_setting(Rs_saveLines))) >= 0)
     saveLines = min (i, MAX_SAVELINES);
 
 #if ENABLE_FRILLS
-  if (rs[Rs_int_bwidth] && (i = atoi (rs[Rs_int_bwidth])) >= 0)
+  if (get_setting(Rs_int_bwidth) && (i = atoi (get_setting(Rs_int_bwidth))) >= 0)
     int_bwidth = min (i, std::numeric_limits<int16_t>::max ());
 
-  if (rs[Rs_ext_bwidth] && (i = atoi (rs[Rs_ext_bwidth])) >= 0)
+  if (get_setting(Rs_ext_bwidth) && (i = atoi (get_setting(Rs_ext_bwidth))) >= 0)
     ext_bwidth = min (i, std::numeric_limits<int16_t>::max ());
 
-  if (rs[Rs_lineSpace] && (i = atoi (rs[Rs_lineSpace])) >= 0)
+  if (get_setting(Rs_lineSpace) && (i = atoi (get_setting(Rs_lineSpace))) >= 0)
     lineSpace = min (i, std::numeric_limits<int16_t>::max ());
 
-  if (rs[Rs_letterSpace])
-    letterSpace = atoi (rs[Rs_letterSpace]);
+  if (get_setting(Rs_letterSpace))
+    letterSpace = atoi (get_setting(Rs_letterSpace));
 #endif
 
 #ifdef POINTER_BLANK
-  if (rs[Rs_pointerBlankDelay] && (i = atoi (rs[Rs_pointerBlankDelay])) >= 0)
+  if (get_setting(Rs_pointerBlankDelay) && (i = atoi (get_setting(Rs_pointerBlankDelay))) >= 0)
     pointerBlankDelay = i;
   else
     pointerBlankDelay = 2;
 #endif
 
-  if (rs[Rs_multiClickTime] && (i = atoi (rs[Rs_multiClickTime])) >= 0)
+  if (get_setting(Rs_multiClickTime) && (i = atoi (get_setting(Rs_multiClickTime))) >= 0)
     multiClickTime = i;
   else
     multiClickTime = 500;
 
-  cursor_type = option (Opt_cursorUnderline) ? 1 : 0;
+  cursor_type = get_option(Opt_cursorUnderline) ? 1 : 0;
 
   /* no point having a scrollbar without having any scrollback! */
   if (!saveLines)
-    set_option (Opt_scrollBar, 0);
+    set_option(Opt_scrollBar, false);
 
-  if (!rs[Rs_cutchars])
-    rs[Rs_cutchars] = CUTCHARS;
+  if (!get_setting(Rs_cutchars))
+  {
+    set_setting(Rs_cutchars, CUTCHARS);
+  }
 
 #ifndef NO_BACKSPACE_KEY
-  if (!rs[Rs_backspace_key])
+  if (!get_setting(Rs_backspace_key))
+  {
 # ifdef DEFAULT_BACKSPACE
-    rs[Rs_backspace_key] = DEFAULT_BACKSPACE;
+    set_setting(Rs_backspace_key, DEFAULT_BACKSPACE);
 # else
-    rs[Rs_backspace_key] = "DEC";       /* can toggle between \010 or \177 */
+    set_setting(Rs_backspace_key, "DEC");       /* can toggle between \010 or \177 */
 # endif
+  }
 #endif
 
 #ifndef NO_DELETE_KEY
-  if (!rs[Rs_delete_key])
+  if (!get_setting(Rs_delete_key))
+  {
 # ifdef DEFAULT_DELETE
-    rs[Rs_delete_key] = DEFAULT_DELETE;
+    set_setting(Rs_delete_key, DEFAULT_DELETE);
 # else
-    rs[Rs_delete_key] = "\033[3~";
+    set_setting(Rs_delete_key, "\033[3~");
 # endif
+  }
 #endif
 
     scrollBar.setup (this);
 
 #ifdef XTERM_REVERSE_VIDEO
   /* this is how xterm implements reverseVideo */
-  if (option (Opt_reverseVideo))
+  if (get_option(Opt_reverseVideo))
+  {
+    if (!get_setting(Rs_color + Color_fg))
     {
-      if (!rs[Rs_color + Color_fg])
-        rs[Rs_color + Color_fg] = def_colorName[Color_bg];
-
-      if (!rs[Rs_color + Color_bg])
-        rs[Rs_color + Color_bg] = def_colorName[Color_fg];
+      set_setting(Rs_color + Color_fg, def_colorName[Color_bg]);
     }
+
+    if (!get_setting(Rs_color + Color_bg))
+    {
+      set_setting(Rs_color + Color_bg, def_colorName[Color_fg]);
+    }
+  }
 #endif
 
   for (i = 0; i < NRS_COLORS; i++)
-    if (!rs[Rs_color + i])
-      rs[Rs_color + i] = def_colorName[i];
+  {
+    if (!get_setting(Rs_color + i))
+    {
+      set_setting(Rs_color + i, def_colorName[i]);
+    }
+  }
 
 #ifndef XTERM_REVERSE_VIDEO
   /* this is how we implement reverseVideo */
-  if (option (Opt_reverseVideo))
-    ::swap (rs[Rs_color + Color_fg], rs[Rs_color + Color_bg]);
+  if (get_option(Opt_reverseVideo))
+  {
+    const char* a = get_setting(Rs_color + Color_fg);
+    const char* b = get_setting(Rs_color + Color_bg);
+
+    set_setting(Rs_color + Color_fg, b);
+    set_setting(Rs_color + Color_bg, a);
+  }
 #endif
 
   /* convenient aliases for setting fg/bg to colors */
@@ -695,8 +725,10 @@ rxvt_term::init_resources (int argc, const char *const *argv)
   color_aliases (Color_RV);
 #endif /* ! NO_BOLD_UNDERLINE_REVERSE */
 
-  if (!rs[Rs_color + Color_border])
-    rs[Rs_color + Color_border] = rs[Rs_color + Color_bg];
+  if (!get_setting(Rs_color + Color_border))
+  {
+    set_setting(Rs_color + Color_border, get_setting(Rs_color + Color_bg));
+  }
 
   return cmd_argv;
 }
@@ -752,7 +784,7 @@ rxvt_term::init2 (int argc, const char *const *argv)
   keyboard->register_done ();
 #endif
 
-  if (const char *path = rs[Rs_chdir])
+  if (const char *path = get_setting(Rs_chdir))
     if (*path) // ignored if empty
       {
         if (*path != '/')
@@ -762,7 +794,7 @@ rxvt_term::init2 (int argc, const char *const *argv)
           rxvt_fatal ("unable to change into specified shell working directory, aborting.\n");
       }
 
-  if (option (Opt_scrollBar))
+  if (get_option(Opt_scrollBar))
     scrollBar.state = SB_STATE_IDLE;    /* set existence for size calculations */
 
   pty = ptytty::create ();
@@ -773,7 +805,7 @@ rxvt_term::init2 (int argc, const char *const *argv)
 
   scr_poweron (); // initialize screen
 
-  if (option (Opt_scrollBar))
+  if (get_option(Opt_scrollBar))
     scrollBar.resize ();      /* create and map scrollbar */
 
 #if ENABLE_PERL
@@ -790,7 +822,7 @@ rxvt_term::init2 (int argc, const char *const *argv)
   HOOK_INVOKE ((this, HOOK_START, DT_END));
 
 #if ENABLE_XEMBED
-  if (rs[Rs_embed])
+  if (get_setting(Rs_embed))
     {
       long info[2] = { 0, XEMBED_MAPPED };
 
@@ -850,15 +882,17 @@ rxvt_term::init_env ()
    *
    * Giving out the display_name also affords a potential security hole
    */
-  val = rxvt_network_display (rs[Rs_display_name]);
-  rs[Rs_display_name] = (const char *)val;
+  val = rxvt_network_display (get_setting(Rs_display_name));
+  set_setting(Rs_display_name, val);
 
   if (val == NULL)
 #endif /* DISPLAY_IS_IP */
     val = XDisplayString (dpy);
 
-  if (rs[Rs_display_name] == NULL)
-    rs[Rs_display_name] = val;   /* use broken `:0' value */
+  if (!get_setting(Rs_display_name))
+  {
+    set_setting(Rs_display_name, val);   /* use broken `:0' value */
+  }
 
   env_display = rxvt_malloc<char>(std::strlen(val) + 9);
 
@@ -890,14 +924,14 @@ rxvt_term::init_env ()
   else
     putenv ("COLORTERM=" COLORTERMENVFULL);
 
-  if (rs[Rs_term_name] != NULL)
-    {
-      env_term = rxvt_malloc<char>(std::strlen(rs[Rs_term_name]) + 6);
-      sprintf (env_term, "TERM=%s", rs[Rs_term_name]);
-      putenv (env_term);
-    }
-  else
+  if (get_setting(Rs_term_name))
+  {
+    env_term = rxvt_malloc<char>(std::strlen(get_setting(Rs_term_name)) + 6);
+    sprintf (env_term, "TERM=%s", get_setting(Rs_term_name));
+    putenv (env_term);
+  } else {
     putenv ("TERM=" TERMENV);
+  }
 
 #ifdef HAVE_UNSETENV
   /* avoid passing old settings and confusing term size */
@@ -982,21 +1016,23 @@ rxvt_term::init_command (const char *const *argv)
    */
 
 #ifdef META8_OPTION
-  meta_char = option (Opt_meta8) ? 0x80 : C0_ESC;
+  meta_char = get_option(Opt_meta8) ? 0x80 : C0_ESC;
 #endif
 
   get_ourmods ();
 
-  if (!option (Opt_scrollTtyOutput))
+  if (!get_option(Opt_scrollTtyOutput))
     priv_modes |= PrivMode_TtyOutputInh;
-  if (option (Opt_scrollTtyKeypress))
+  if (get_option(Opt_scrollTtyKeypress))
     priv_modes |= PrivMode_Keypress;
-  if (!option (Opt_jumpScroll))
+  if (!get_option(Opt_jumpScroll))
     priv_modes |= PrivMode_smoothScroll;
 
 #ifndef NO_BACKSPACE_KEY
-  if (strcmp (rs[Rs_backspace_key], "DEC") == 0)
+  if (!std::strcmp(get_setting(Rs_backspace_key), "DEC"))
+  {
     priv_modes |= PrivMode_HaveBackSpace;
+  }
 #endif
 
   /* add value for scrollBar */
@@ -1020,8 +1056,14 @@ rxvt_term::get_colors ()
 #endif
 
   for (i = 0; i < NRS_COLORS; i++)
-    if (const char *name = rs[Rs_color + i])
-      set_color (pix_colors [i], name);
+  {
+    const char* name = get_setting(Rs_color + i);
+
+    if (name)
+    {
+      set_color(pix_colors[i], name);
+    }
+  }
 
   /*
    * get scrollBar shadow colors
@@ -1055,19 +1097,25 @@ rxvt_term::get_colors ()
 /*----------------------------------------------------------------------*/
 /* color aliases, fg/bg bright-bold */
 void
-rxvt_term::color_aliases (int idx)
+rxvt_term::color_aliases(int idx)
 {
-  if (rs[Rs_color + idx] && isdigit (*rs[Rs_color + idx]))
-    {
-      int i = atoi (rs[Rs_color + idx]);
+  const char* color = get_setting(Rs_color + idx);
 
-      if (i >= 8 && i <= 15)
-        /* bright colors */
-        rs[Rs_color + idx] = rs[Rs_color + minBrightCOLOR + i - 8];
-      else if (i >= 0 && i <= 7)
-        /* normal colors */
-        rs[Rs_color + idx] = rs[Rs_color + minCOLOR + i];
+  if (color && isdigit(*color))
+  {
+    const int i = std::atoi(color);
+
+    if (i >= 8 && i <= 15)
+    {
+      /* bright colors */
+      set_setting(Rs_color + idx, get_setting(Rs_color + minBrightCOLOR + i - 8));
     }
+    else if (i >= 0 && i <= 7)
+    {
+      /* normal colors */
+      set_setting(Rs_color + idx, get_setting(Rs_color + minCOLOR + i));
+    }
+  }
 }
 
 /*----------------------------------------------------------------------*/
@@ -1089,7 +1137,7 @@ rxvt_term::get_ourmods ()
     };
 
   requestedmeta = realmeta = realalt = 0;
-  rsmod = rs[Rs_modifier];
+  rsmod = get_setting(Rs_modifier);
 
   if (rsmod
       && strcasecmp (rsmod, "mod1") >= 0 && strcasecmp (rsmod, "mod5") <= 0)
@@ -1244,10 +1292,10 @@ rxvt_term::create_windows (int argc, const char *const *argv)
 
   parent = display->root;
 
-  attributes.override_redirect = !!option (Opt_override_redirect);
+  attributes.override_redirect = !!get_option(Opt_override_redirect);
 
 #if ENABLE_FRILLS
-  if (option (Opt_borderLess))
+  if (get_option(Opt_borderLess))
     {
       if (XInternAtom (dpy, "_MOTIF_WM_INFO", True) == None)
         {
@@ -1262,11 +1310,11 @@ rxvt_term::create_windows (int argc, const char *const *argv)
 #endif
 
 #if ENABLE_XEMBED
-  if (rs[Rs_embed])
+  if (get_setting(Rs_embed))
     {
       XWindowAttributes wattr;
 
-      parent = strtol (rs[Rs_embed], 0, 0);
+      parent = strtol (get_setting(Rs_embed), 0, 0);
 
       if (!XGetWindowAttributes (dpy, parent, &wattr))
         rxvt_fatal ("invalid window-id specified with -embed, aborting.\n");
@@ -1292,16 +1340,17 @@ rxvt_term::create_windows (int argc, const char *const *argv)
 
   this->parent = top;
 
-  set_title     (rs [Rs_title]);
-  set_icon_name (rs [Rs_iconName]);
+  set_title     (get_setting(Rs_title));
+  set_icon_name (get_setting(Rs_iconName));
 
-  classHint.res_name  = (char *)rs[Rs_name];
+  classHint.res_name = strdup(get_setting(Rs_name));
+  allocated.push_back(classHint.res_name);
   classHint.res_class = (char *)RESCLASS;
 
   wmHint.flags         = InputHint | StateHint | WindowGroupHint;
   wmHint.input         = True;
-  wmHint.initial_state = option (Opt_iconic) ? IconicState
-                         : option (Opt_dockapp) ? WithdrawnState
+  wmHint.initial_state = get_option(Opt_iconic) ? IconicState
+                         : get_option(Opt_dockapp) ? WithdrawnState
                          : NormalState;
   wmHint.window_group  = top;
 
@@ -1310,11 +1359,11 @@ rxvt_term::create_windows (int argc, const char *const *argv)
 #if ENABLE_EWMH
   /*
    * set up icon hint
-   * rs [Rs_iconfile] is path to icon
+   * get_setting(Rs_iconfile) is path to icon
    */
 
-  if (rs [Rs_iconfile])
-    set_icon (rs [Rs_iconfile]);
+  if (get_setting(Rs_iconfile))
+    set_icon (get_setting(Rs_iconfile));
 #endif
 
 #if ENABLE_FRILLS
@@ -1333,8 +1382,8 @@ rxvt_term::create_windows (int argc, const char *const *argv)
   XSetWMProtocols (dpy, top, protocols, ecb_array_length (protocols));
 
 #if ENABLE_FRILLS
-  if (rs[Rs_transient_for])
-    XSetTransientForHint (dpy, top, (Window)strtol (rs[Rs_transient_for], 0, 0));
+  if (get_setting(Rs_transient_for))
+    XSetTransientForHint (dpy, top, (Window)strtol (get_setting(Rs_transient_for), 0, 0));
 #endif
 
 #if ENABLE_EWMH
@@ -1361,9 +1410,9 @@ rxvt_term::create_windows (int argc, const char *const *argv)
   unsigned int shape = XC_xterm;
 
 #ifdef HAVE_XMU
-  if (rs[Rs_pointerShape])
+  if (get_setting(Rs_pointerShape))
     {
-      int stmp = XmuCursorNameToIndex (rs[Rs_pointerShape]);
+      int stmp = XmuCursorNameToIndex (get_setting(Rs_pointerShape));
       if (stmp >= 0)
         shape = stmp;
     }
@@ -1384,7 +1433,7 @@ rxvt_term::create_windows (int argc, const char *const *argv)
 
   vt_emask = ExposureMask | ButtonPressMask | ButtonReleaseMask | PropertyChangeMask;
 
-  if (option (Opt_pointerBlank))
+  if (get_option(Opt_pointerBlank))
     vt_emask |= PointerMotionMask;
   else
     vt_emask |= Button1MotionMask | Button3MotionMask;
@@ -1406,7 +1455,7 @@ rxvt_term::create_windows (int argc, const char *const *argv)
 
 #ifdef OFF_FOCUS_FADING
   // initially we are in unfocused state
-  if (rs[Rs_fade])
+  if (get_setting(Rs_fade))
     pix_colors = pix_colors_unfocused;
 #endif
 
@@ -1424,9 +1473,9 @@ void
 rxvt_term::run_command (const char *const *argv)
 {
 #if ENABLE_FRILLS
-  if (rs[Rs_pty_fd])
+  if (get_setting(Rs_pty_fd))
     {
-      pty->pty = atoi (rs[Rs_pty_fd]);
+      pty->pty = atoi (get_setting(Rs_pty_fd));
 
       if (pty->pty >= 0)
         {
@@ -1447,9 +1496,9 @@ rxvt_term::run_command (const char *const *argv)
   struct termios tio = def_tio;
 
 #ifndef NO_BACKSPACE_KEY
-  if (rs[Rs_backspace_key][0] && !rs[Rs_backspace_key][1])
-    tio.c_cc[VERASE] = rs[Rs_backspace_key][0];
-  else if (strcmp (rs[Rs_backspace_key], "DEC") == 0)
+  if (get_setting(Rs_backspace_key)[0] && !get_setting(Rs_backspace_key)[1])
+    tio.c_cc[VERASE] = get_setting(Rs_backspace_key)[0];
+  else if (strcmp (get_setting(Rs_backspace_key), "DEC") == 0)
     tio.c_cc[VERASE] = '\177';            /* the initial state anyway */
 #endif
 
@@ -1463,7 +1512,7 @@ rxvt_term::run_command (const char *const *argv)
   tt_winch ();
 
 #if ENABLE_FRILLS
-  if (rs[Rs_pty_fd])
+  if (get_setting(Rs_pty_fd))
     return;
 #endif
 
@@ -1501,14 +1550,14 @@ rxvt_term::run_command (const char *const *argv)
         _exit (EXIT_FAILURE);
 
       default:
-        if (!option (Opt_utmpInhibit))
+        if (!get_option(Opt_utmpInhibit))
           {
 #ifdef LOG_ONLY_ON_LOGIN
-            bool login_shell = option (Opt_loginShell);
+            bool login_shell = get_option(Opt_loginShell);
 #else
             bool login_shell = true;
 #endif
-            pty->login (cmd_pid, login_shell, rs[Rs_display_name]);
+            pty->login (cmd_pid, login_shell, get_setting(Rs_display_name));
           }
 
         pty->close_tty ();
@@ -1532,7 +1581,7 @@ rxvt_term::run_child (const char *const *argv)
 {
   char *login;
 
-  if (option (Opt_console))
+  if (get_option(Opt_console))
     {
       /* be virtual console, fail silently */
 #ifdef TIOCCONS
@@ -1589,7 +1638,7 @@ rxvt_term::run_child (const char *const *argv)
 
       argv0 = rxvt_basename (shell);
 
-      if (option (Opt_loginShell))
+      if (get_option(Opt_loginShell))
         {
           login = rxvt_malloc<char>(std::strlen(argv0) + 2);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,7 +141,6 @@ int rxvt_composite_vec::expand (unicode_t c, wchar_t *r)
 #endif
 
 rxvt_term::rxvt_term()
-  : xdg_handle_initialized(false)
 {
 #ifdef CURSOR_BLINK
   cursor_blink_ev.set     <rxvt_term, &rxvt_term::cursor_blink_cb> (this); cursor_blink_ev.set (0., CURSOR_BLINK_INTERVAL);
@@ -185,11 +184,6 @@ rxvt_term::rxvt_term()
 #ifdef KEYSYM_RESOURCE
   keyboard = new keyboard_manager;
 #endif
-
-  if (xdgInitHandle(&xdg_handle))
-  {
-    xdg_handle_initialized = true;
-  }
 }
 
 // clean up the most important stuff, do *not* call x or free mem etc.
@@ -283,11 +277,6 @@ rxvt_term::~rxvt_term ()
 #ifndef NO_RESOURCES
   XrmDestroyDatabase (option_db);
 #endif
-
-  if (xdg_handle_initialized)
-  {
-    xdgWipeHandle(&xdg_handle);
-  }
 
   SET_R ((rxvt_term *)0);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -245,7 +245,7 @@ rxvt_term::~rxvt_term ()
           {
             pix_colors_focused   [i].free (this);
 #if OFF_FOCUS_FADING
-            if (rs[Rs_fade])
+            if (get_setting(Rs_fade))
               pix_colors_unfocused [i].free (this);
 #endif
           }
@@ -300,7 +300,7 @@ rxvt_term::child_cb (ev::child &w, int status)
 
   cmd_pid = 0;
 
-  if (!option (Opt_hold))
+  if (!get_option(Opt_hold))
     destroy ();
 }
 
@@ -356,18 +356,6 @@ rxvt_term::destroy_cb (ev::idle &w, int revents)
   make_current ();
 
   delete this;
-}
-
-void
-rxvt_term::set_option (uint8_t opt, bool set) NOTHROW
-{
-  if (!opt)
-    return;
-
-  uint8_t mask = 1 << (opt & 7);
-  uint8_t &val = options [opt >> 3];
-
-  val = val & ~mask | (set ? mask : 0);
 }
 
 /*----------------------------------------------------------------------*/
@@ -629,8 +617,8 @@ rxvt_term::window_calc (unsigned int newwidth, unsigned int newheight)
     {
       parsed_geometry = 1;
 
-      if (rs[Rs_geometry])
-        flags = XParseGeometry (rs[Rs_geometry], &x, &y, &w, &h);
+      if (get_setting(Rs_geometry))
+        flags = XParseGeometry (get_setting(Rs_geometry), &x, &y, &w, &h);
 
       if (flags & WidthValue)
         {
@@ -694,7 +682,7 @@ rxvt_term::window_calc (unsigned int newwidth, unsigned int newheight)
       int sb_w = scrollBar.total_width ();
       szHint.base_width += sb_w;
 
-      if (!option (Opt_scrollBar_right))
+      if (!get_option(Opt_scrollBar_right))
         window_vt_x += sb_w;
     }
 
@@ -773,7 +761,7 @@ rxvt_term::set_fonts ()
   rxvt_fontprop prop;
 
   if (!fs
-      || !fs->populate (rs[Rs_font] ? rs[Rs_font] : "fixed")
+      || !fs->populate (get_setting(Rs_font) ? get_setting(Rs_font) : "fixed")
       || !fs->realize_font (1))
     {
       delete fs;
@@ -801,7 +789,7 @@ rxvt_term::set_fonts ()
   for (int style = 1; style < 4; style++)
     {
 #if ENABLE_STYLES
-      const char *res = rs[Rs_font + style];
+      const char *res = get_setting(Rs_font + style);
 
       if (res && !*res)
         fontset[style] = fontset[0];
@@ -914,42 +902,42 @@ void
 rxvt_term::set_window_color (int idx, const char *color)
 {
 #ifdef XTERM_COLOR_CHANGE
-  if (color == NULL || *color == '\0')
+  if (!color || !*color)
+  {
     return;
+  }
 
-  color = strdup (color);
-  allocated.push_back ((void *)color);
-  rs[Rs_color + idx] = color;
+  set_setting(Rs_color + idx, color);
 
   /* handle color aliases */
   if (isdigit (*color))
+  {
+    const int i = std::atoi(color);
+
+    if (i >= 8 && i <= 15)
     {
-      int i = atoi (color);
-
-      if (i >= 8 && i <= 15)
-        {
-          /* bright colors */
-          alias_color (idx, minBrightCOLOR + i - 8);
-          goto done;
-        }
-
-      if (i >= 0 && i <= 7)
-        {
-          /* normal colors */
-          alias_color (idx, minCOLOR + i);
-          goto done;
-        }
+      /* bright colors */
+      alias_color(idx, minBrightCOLOR + i - 8);
+      goto done;
     }
 
-  pix_colors_focused[idx].free (this);
-  set_color (pix_colors_focused[idx], color);
+    if (i >= 0 && i <= 7)
+    {
+      /* normal colors */
+      alias_color(idx, minCOLOR + i);
+      goto done;
+    }
+  }
+
+  pix_colors_focused[idx].free(this);
+  set_color(pix_colors_focused[idx], color);
 
 done:
   /*TODO: handle Color_BD, scrollbar background, etc. */
 
-  update_fade_color (idx);
-  recolor_cursor ();
-  scr_recolor ();
+  update_fade_color(idx);
+  recolor_cursor();
+  scr_recolor();
 #endif /* XTERM_COLOR_CHANGE */
 }
 
@@ -1017,10 +1005,13 @@ rxvt_term::set_color (rxvt_color &color, const char *name)
 }
 
 void
-rxvt_term::alias_color (int dst, int src)
+rxvt_term::alias_color(int dst, int src)
 {
-  pix_colors[dst].free (this);
-  pix_colors[dst].set (this, rs[Rs_color + dst] = rs[Rs_color + src]);
+  const char* color = get_setting(Rs_color + src);
+
+  pix_colors[dst].free(this);
+  set_setting(Rs_color + dst, color);
+  pix_colors[dst].set(this, color);
 }
 
 #ifdef SMART_RESIZE
@@ -1300,15 +1291,15 @@ xim_preedit_draw (XIC ic, XPointer client_data, XIMPreeditDrawCallbackStruct *ca
       if (!text->encoding_is_wchar && text->string.multi_byte)
         {
           // of course, X makes it ugly again
-          if (term->rs[Rs_imLocale])
+          if (term->get_setting(Rs_imLocale))
           {
-            rxvt_set_locale(term->rs[Rs_imLocale]);
+            rxvt_set_locale(term->get_setting(Rs_imLocale));
           }
 
           str = rxvt_temp_buf<wchar_t> (text->length + 1);
           mbstowcs (str, text->string.multi_byte, text->length + 1);
 
-          if (term->rs[Rs_imLocale])
+          if (term->get_setting(Rs_imLocale))
           {
             rxvt_set_locale(term->locale);
           }
@@ -1369,7 +1360,7 @@ rxvt_term::im_get_ic (const char *modifiers)
       return false;
     }
 
-  const char *pet[] = { rs[Rs_preeditType], "OverTheSpot,OffTheSpot,Root,None" };
+  const char *pet[] = { get_setting(Rs_preeditType), "OverTheSpot,OffTheSpot,Root,None" };
 
   for (int pi = 0; pi < 2; pi++)
     {
@@ -1443,7 +1434,7 @@ foundpet:
                fheight + 1, fheight - 1,
                fheight - 2, fheight + 2);
 
-      fs = XCreateFontSet (dpy, rs[Rs_imFont] ? rs[Rs_imFont] : pat,
+      fs = XCreateFontSet (dpy, get_setting(Rs_imFont) ? get_setting(Rs_imFont) : pat,
                            &missing_charset_list, &missing_charset_count, &def_string);
 
       if (missing_charset_list)
@@ -1554,12 +1545,12 @@ rxvt_term::im_cb ()
   if (Input_Context)
     return;
 
-  if (rs[Rs_imLocale])
+  if (get_setting(Rs_imLocale))
   {
-    rxvt_set_locale(rs[Rs_imLocale]);
+    rxvt_set_locale(get_setting(Rs_imLocale));
   }
 
-  p = rs[Rs_inputMethod];
+  p = get_setting(Rs_inputMethod);
   if (p && *p)
     {
       bool found = false;
@@ -1595,7 +1586,7 @@ rxvt_term::im_cb ()
     goto done;
 
 done:
-  if (rs[Rs_imLocale])
+  if (get_setting(Rs_imLocale))
   {
     rxvt_set_locale(locale);
   }

--- a/src/rxvt.h
+++ b/src/rxvt.h
@@ -34,7 +34,6 @@ extern "C" {
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xresource.h>
-#include <basedir.h>
 }
 
 #if UNICODE_3
@@ -1143,9 +1142,6 @@ struct rxvt_term : zero_initialized, rxvt_vars, rxvt_screen
   uint32_t        rgb24_color[RGB24_CUBE_SIZE];   // the 24-bit color value
   uint16_t        rgb24_seqno[RGB24_CUBE_SIZE];   // which one is older?
   uint16_t        rgb24_sequence;
-
-  xdgHandle xdg_handle;
-  bool xdg_handle_initialized;
 
   static vector<rxvt_term *> termlist; // a vector of all running rxvt_term's
 

--- a/src/rxvtfont.cpp
+++ b/src/rxvtfont.cpp
@@ -288,7 +288,7 @@ struct rxvt_font_default : rxvt_font {
 
 #ifdef BUILTIN_GLYPHS
     if (unicode >= 0x2500 && unicode <= 0x259f &&
-        !term->option (Opt_skipBuiltinGlyphs))
+        !term->get_option(Opt_skipBuiltinGlyphs))
       return true;
 #endif
 
@@ -1321,7 +1321,7 @@ rxvt_font_xft::draw (rxvt_drawable &d, int x, int y,
   int h = term->fheight;
 
   bool buffered = bg >= Color_transparent
-                  && term->option (Opt_buffered);
+                  && term->get_option(Opt_buffered);
 
   // cut trailing spaces
   while (len && text [len - 1] == ' ')

--- a/src/rxvtperl.xs
+++ b/src/rxvtperl.xs
@@ -1826,19 +1826,12 @@ rxvt_term::_resource (octet_string name, int index, SV *newval = 0)
           croak ("requested out-of-bound resource %s+%d,", name, index - rs->value);
 
         if (GIMME_V != G_VOID)
-          XPUSHs (THIS->rs [index] ? sv_2mortal (newSVpv (THIS->rs [index], 0)) : &PL_sv_undef);
+          XPUSHs (THIS->get_setting(index) ? sv_2mortal (newSVpv (THIS->get_setting(index), 0)) : &PL_sv_undef);
 
         if (newval)
-          {
-            if (SvOK (newval))
-              {
-                char *str = strdup (SvPVbyte_nolen (newval));
-                THIS->rs [index] = str;
-                THIS->allocated.push_back (str);
-              }
-            else
-              THIS->rs [index] = 0;
-          }
+        {
+          THIS->set_setting(index, SvOK(newval) ? SvPVbyte_nolen(newval) : nullptr);
+        }
 }
 
 const char *
@@ -1848,11 +1841,11 @@ bool
 rxvt_term::option (U8 optval, int set = -1)
 	CODE:
 {
-	RETVAL = THIS->option (optval);
+	RETVAL = THIS->get_option(optval);
 
         if (set >= 0)
           {
-            THIS->set_option (optval, set);
+            THIS->set_option(optval, set);
 
             if (THIS->init_done) // avoid doing this before START
               switch (optval)

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -43,7 +43,7 @@ fill_text (text_t *start, text_t value, int len)
  *             GENERAL SCREEN AND SELECTION UPDATE ROUTINES                  *
  * ------------------------------------------------------------------------- */
 #define ZERO_SCROLLBACK()                                              \
-    if (option (Opt_scrollTtyOutput))                                  \
+    if (get_option(Opt_scrollTtyOutput))                                  \
         view_start = 0
 #define CLEAR_SELECTION()                                              \
     selection.beg.row = selection.beg.col                              \
@@ -536,7 +536,7 @@ rxvt_term::scr_cursor (cursor_mode mode) NOTHROW
 void
 rxvt_term::scr_swap_screen () NOTHROW
 {
-  if (!option (Opt_secondaryScreen))
+  if (!get_option(Opt_secondaryScreen))
     return;
 
   for (int i = prev_nrow; i--; )
@@ -573,7 +573,7 @@ rxvt_term::scr_change_screen (int scrn)
   current_screen = scrn;
 
 #if NSCREENS
-  if (option (Opt_secondaryScreen))
+  if (get_option(Opt_secondaryScreen))
     {
       num_scr = 0;
 
@@ -586,7 +586,7 @@ rxvt_term::scr_change_screen (int scrn)
     }
   else
 #endif
-    if (option (Opt_secondaryScroll))
+    if (get_option(Opt_secondaryScroll))
       scr_scroll_text (0, prev_nrow - 1, prev_nrow);
 }
 
@@ -655,7 +655,7 @@ rxvt_term::scr_scroll_text (int row1, int row2, int count) NOTHROW
 
   if (count > 0
       && row1 == 0
-      && (current_screen == PRIMARY || option (Opt_secondaryScroll)))
+      && (current_screen == PRIMARY || get_option(Opt_secondaryScroll)))
     {
       min_it (count, total_rows - (nrow - (row2 + 1)));
 
@@ -712,7 +712,7 @@ rxvt_term::scr_scroll_text (int row1, int row2, int count) NOTHROW
         }
 
       // finally move the view window, if desired
-      if (option (Opt_scrollWithBuffer)
+      if (get_option(Opt_scrollWithBuffer)
           && view_start != 0
           && view_start != -saveLines)
         scr_page (count);
@@ -1104,7 +1104,7 @@ rxvt_term::scr_tab (int count, bool ht) NOTHROW
 
       // store horizontal tab commands as characters inside the text
       // buffer so they can be selected and pasted.
-      if (ht && option (Opt_pastableTabs))
+      if (ht && get_option(Opt_pastableTabs))
         {
           base_rend = SET_FONT (base_rend, 0);
 
@@ -1718,7 +1718,7 @@ rxvt_term::scr_rvideo_mode (bool on) NOTHROW
       rvideo_state = on;
 
 #if OFF_FOCUS_FADING
-      if (rs[Rs_fade])
+      if (get_setting(Rs_fade))
         {
           ::swap (pix_colors_focused[Color_fg], pix_colors_focused[Color_bg]);
           ::swap (pix_colors_unfocused[Color_fg], pix_colors_unfocused[Color_bg]);
@@ -1928,17 +1928,17 @@ rxvt_term::scr_bell () NOTHROW
 
 # ifndef NO_MAPALERT
 #  ifdef MAPALERT_OPTION
-  if (option (Opt_mapAlert))
+  if (get_option(Opt_mapAlert))
 #  endif
     XMapWindow (dpy, parent);
 # endif
 
 # if ENABLE_FRILLS
-  if (option (Opt_urgentOnBell))
+  if (get_option(Opt_urgentOnBell))
     set_urgency (1);
 # endif
 
-  if (option (Opt_visualBell))
+  if (get_option(Opt_visualBell))
     {
       rvideo_bell = true;
       scr_rvideo_mode (rvideo_mode);
@@ -2961,7 +2961,7 @@ rxvt_term::selection_start_colrow (int col, int row) NOTHROW
 
 /* what do we want: spaces/tabs are delimiters or cutchars or non-cutchars */
 #define DELIMIT_TEXT(x)		\
-    (unicode::is_space (x) ? 2 : (x) <= 0xff && !!std::strchr(rs[Rs_cutchars], (x)))
+    (unicode::is_space (x) ? 2 : (x) <= 0xff && !!std::strchr(get_setting(Rs_cutchars), (x)))
 #define DELIMIT_REND(x)        1
 
 void ecb_cold
@@ -3224,7 +3224,7 @@ rxvt_term::selection_extend_colrow (int32_t col, int32_t row, int button3, int b
   else if (selection.clicks == 3)
     {
 #if ENABLE_FRILLS
-      if (option (Opt_tripleclickwords))
+      if (get_option(Opt_tripleclickwords))
         {
           selection_delimit_word (UP, &selection.beg, &selection.beg);
 

--- a/src/scrollbar-plain.cpp
+++ b/src/scrollbar-plain.cpp
@@ -43,7 +43,7 @@ scrollBar_t::show_plain (int update)
       pscrollbarGC = XCreateGC (term->dpy, win, GCForeground, &gcvalue);
     }
 
-  xsb = term->option (Opt_scrollBar_right) ? 1 : 0;
+  xsb = term->get_option(Opt_scrollBar_right) ? 1 : 0;
 
   if (update)
     {

--- a/src/scrollbar-xterm.cpp
+++ b/src/scrollbar-xterm.cpp
@@ -59,7 +59,7 @@ scrollBar_t::show_xterm (int update)
       ShadowGC = XCreateGC (term->dpy, win, GCForeground, &gcvalue);
     }
 
-  xsb = term->option (Opt_scrollBar_right) ? 1 : 0;
+  xsb = term->get_option(Opt_scrollBar_right) ? 1 : 0;
 
   if (update)
     {

--- a/src/scrollbar.cpp
+++ b/src/scrollbar.cpp
@@ -58,7 +58,7 @@ scrollBar_t::resize ()
   int delayed_init = 0;
   int window_sb_x = 0;
 
-  if (term->option (Opt_scrollBar_right))
+  if (term->get_option(Opt_scrollBar_right))
     window_sb_x = term->szHint.width - total_width ();
 
   update_data ();
@@ -139,9 +139,9 @@ scrollBar_t::setup (rxvt_term *term)
   const char *scrollalign, *scrollstyle, *thickness;
 
   this->term = term;
-  scrollalign = term->rs[Rs_scrollBar_align];
-  scrollstyle = term->rs[Rs_scrollstyle];
-  thickness = term->rs[Rs_scrollBar_thickness];
+  scrollalign = term->get_setting(Rs_scrollBar_align);
+  scrollstyle = term->get_setting(Rs_scrollstyle);
+  thickness = term->get_setting(Rs_scrollBar_thickness);
 
 # if defined(RXVT_SCROLLBAR)
   style = SB_STYLE_RXVT;
@@ -187,7 +187,7 @@ scrollBar_t::setup (rxvt_term *term)
       width = min (i, SB_WIDTH_MAXIMUM);
 
 # ifdef RXVT_SCROLLBAR
-  if (! term->option (Opt_scrollBar_floating) && style == SB_STYLE_RXVT)
+  if (! term->get_option(Opt_scrollBar_floating) && style == SB_STYLE_RXVT)
     shadow = SHADOW_WIDTH;
 # endif
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -25,6 +25,7 @@
  *----------------------------------------------------------------------*/
 
 #include "../config.h"
+
 #include "rxvt.h"
 #include "version.h"
 
@@ -32,6 +33,7 @@
 #include <fstream>
 #include <vector>
 
+#include <basedir.h>
 #include <toml/toml.h>
 
 #ifdef KEYSYM_RESOURCE
@@ -957,7 +959,7 @@ load_settings_from(rxvt_term* term, const std::string& filename)
 void
 rxvt_term::load_settings()
 {
-  const char* const* config_dirs = xdgSearchableConfigDirectories(&xdg_handle);
+  const char* const* config_dirs = xdgSearchableConfigDirectories(nullptr);
 
   for (; config_dirs && *config_dirs; ++config_dirs)
   {


### PR DESCRIPTION
Hash maps seem to work better even with dynamically created enums being used as indexes, rather than fixed sized arrays, so use them instead for storing settings of the terminal.