### PR TITLE
Use std::wstring in selection structure

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -787,19 +787,19 @@ rxvt_term::key_press (XKeyEvent &ev)
         }
 
       if (ctrl && meta && (keysym == XK_c || keysym == XK_v))
+      {
+        if (keysym == XK_v)
         {
-          if (keysym == XK_v)
-            selection_request (ev.time, Sel_Clipboard);
-          else if (selection.len > 0)
-            {
-              free (selection.clip_text);
-              selection.clip_text = rxvt_wcsdup (selection.text, selection.len);
-              selection.clip_len = selection.len;
-              selection_grab (CurrentTime, true);
-            }
-
-          return;
+          selection_request(ev.time, Sel_Clipboard);
         }
+        else if (!selection.text.empty())
+        {
+          selection.clip_text = selection.text;
+          selection_grab(CurrentTime, true);
+        }
+
+        return;
+      }
 
 #if ENABLE_FRILLS || ISO_14755
       // ISO 14755 support

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -262,8 +262,6 @@ rxvt_term::~rxvt_term()
   for (int i = 0; i < allocated.size (); i++)
     free (allocated [i]);
 
-  free (selection.text);
-  free (selection.clip_text);
   free (v_buffer);
 
   delete selection_req;

--- a/src/rxvt.h
+++ b/src/rxvt.h
@@ -908,8 +908,8 @@ enum selection_op_t
 
 struct selection_t
 {
-  wchar_t          *text;       /* selected text                             */
-  unsigned int      len;        /* length of selected text                   */
+  /** Selected text. */
+  std::wstring text;
   unsigned int      screen;     /* screen being used                         */
   unsigned int      clicks;     /* number of clicks                          */
   selection_op_t    op;         /* current operation                         */
@@ -917,8 +917,8 @@ struct selection_t
   row_col_t         beg;        /* beginning of selection   <= mark          */
   row_col_t         mark;       /* point of initial click   <= end           */
   row_col_t         end;        /* one character past end point              */
-  wchar_t          *clip_text;  /* text copied to the clipboard              */
-  unsigned int      clip_len;   /* length of clipboard text                  */
+  /** Text copied to the clipboard. */
+  std::wstring clip_text;
 };
 
 /* ------------------------------------------------------------------------- */

--- a/src/rxvtperl.xs
+++ b/src/rxvtperl.xs
@@ -120,14 +120,14 @@ sv2wcs (SV *sv)
   return rxvt_utf8towcs (str, len);
 }
 
-static SV *
-wcs2sv (wchar_t *wstr, int len = -1)
+static SV*
+wcs2sv(const wchar_t* wstr, int len = -1)
 {
-  char *str = rxvt_wcstoutf8 (wstr, len);
+  auto str = rxvt_wcstoutf8(wstr, len);
+  auto sv = newSVpv(str, 0);
 
-  SV *sv = newSVpv (str, 0);
-  SvUTF8_on (sv);
-  free (str);
+  SvUTF8_on(sv);
+  std::free(str);
 
   return sv;
 }
@@ -2007,24 +2007,28 @@ int
 rxvt_term::selection_grab (Time eventtime, bool clipboard = false)
 
 void
-rxvt_term::selection (SV *newtext = 0, bool clipboard = false)
-        PPCODE:
+rxvt_term::selection(SV* newtext = nullptr, bool clipboard = false)
+  PPCODE:
 {
-        wchar_t * &text   = clipboard ? THIS->selection.clip_text : THIS->selection.text;
-        unsigned int &len = clipboard ? THIS->selection.clip_len  : THIS->selection.len;
+  auto& text = (
+    clipboard ?
+    THIS->selection.clip_text :
+    THIS->selection.text
+  );
 
-        if (GIMME_V != G_VOID)
-          XPUSHs (text
-                  ? sv_2mortal (wcs2sv (text, len))
-                  : &PL_sv_undef);
+  if (GIMME_V != G_VOID)
+  {
+    XPUSHs(
+      !text.empty() ?
+      sv_2mortal(wcs2sv(text.c_str(), text.length())) :
+      &PL_sv_undef
+    );
+  }
 
-        if (newtext)
-          {
-            free (text);
-
-            text = sv2wcs (newtext);
-            len = wcslen (text);
-          }
+  if (newtext)
+  {
+    text = sv2wcs(newtext);
+  }
 }
 
 char

--- a/src/rxvttoolkit.cpp
+++ b/src/rxvttoolkit.cpp
@@ -462,8 +462,8 @@ rxvt_selection::run ()
   {
     /* internal selection */
     auto str = rxvt_wcstombs(
-      display->selection_owner()->selection.text,
-      display->selection_owner()->selection.len
+      display->selection_owner()->selection.text.c_str(),
+      display->selection_owner()->selection.text.length()
     );
 
     finish(str, std::strlen(str));


### PR DESCRIPTION
Use features provided by the C++ standard library instead of character
pointers in the selection structure.