### PR TITLE
Add suppport for wide glyphs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -39,14 +39,14 @@ rxvt:
 	(cd src; $(MAKE))
 
 #-------------------------------------------------------------------------
-configure: configure.ac aclocal.m4 ./libev/libev.m4 ./libptytty/ptytty.m4
+configure: configure.ac aclocal.m4 ./libev/libev.m4
 	cd $(srcdir); ./autogen.sh
 
 config.status:
 	if test -x config.status; then config.status --recheck; \
 	else $(SHELL) configure; fi
 
-config.h.in: configure.ac aclocal.m4 ./libev/libev.m4 ./libptytty/ptytty.m4
+config.h.in: configure.ac aclocal.m4 ./libev/libev.m4
 	cd $(srcdir); ./autogen.sh
 
 check: all

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1,4 +1,4 @@
-m4_include([deps/libptytty/ptytty.m4])
+m4_include([ptytty.m4])
 
 dnl maybe import pkg.m4 and use PKG_CHECK_MODULES in place of this macro
 AC_DEFUN([RXVT_CHECK_MODULES],

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,7 +1,6 @@
 #! /bin/sh
 
 for filename in deps/libev/ev++.h \
-                deps/libptytty/src/libptytty.h \
                 deps/tinytoml/include/toml/toml.h
 do
   if test ! -e "$filename"

--- a/config.h.in
+++ b/config.h.in
@@ -18,6 +18,9 @@
 /* Define if you want your background to use the parent window background */
 #undef ENABLE_TRANSPARENCY
 
+/* Define if you want to display wide glyphs */
+#undef ENABLE_WIDE_GLYPHS
+
 /* Define if you want european extended codesets */
 #undef ENCODING_EU
 

--- a/configure
+++ b/configure
@@ -716,6 +716,7 @@ enable_warnings
 enable_unicode3
 enable_combining
 enable_font_styles
+enable_wide_glyphs
 enable_pixbuf
 enable_startup_notification
 enable_transparency
@@ -1398,6 +1399,7 @@ Optional Features:
   --enable-unicode3       use 21 instead of 16 bits to represent unicode characters
   --enable-combining      enable composition of base and combining characters
   --enable-font-styles    enable bold and italic support
+ --enable-wide-glyphs     enable displaying of wide glyphs
   --enable-pixbuf         enable integration with gdk-pixbuf for background images
   --enable-startup-notification  enable freedesktop startup notification support
   --enable-transparency   enable transparent backgrounds
@@ -4721,6 +4723,7 @@ support_combining=yes
 support_8bitctrls=no
 support_iso14755=yes
 support_styles=yes
+support_wide_glyphs=yes
 support_perl=yes
 codesets=all
 
@@ -4752,6 +4755,7 @@ if test "${enable_everything+set}" = set; then :
        support_8bitctrls=no
        support_iso14755=no
        support_styles=no
+       support_wide_glyphs=yes
        support_perl=no
        codesets=
     fi
@@ -4854,6 +4858,14 @@ fi
 if test "${enable_font_styles+set}" = set; then :
   enableval=$enable_font_styles; if test x$enableval = xyes -o x$enableval = xno; then
     support_styles=$enableval
+  fi
+fi
+
+
+# Check whether --enable-wide-glyphs was given.
+if test "${enable_wide_glyphs+set}" = set; then :
+  enableval=$enable_wide_glyphs; if test x$enableval = xyes -o x$enableval = xno; then
+    support_wide_glyphs=$enableval
   fi
 fi
 
@@ -7671,6 +7683,11 @@ fi
 if test x$support_styles = xyes; then
 
 $as_echo "#define ENABLE_STYLES 1" >>confdefs.h
+
+fi
+if test x$support_wide_glyphs = xyes; then
+
+$as_echo "#define ENABLE_WIDE_GLYPHS 1" >>confdefs.h
 
 fi
 if test x$support_iso14755 = xyes; then

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,7 @@ support_combining=yes
 support_8bitctrls=no
 support_iso14755=yes
 support_styles=yes
+support_wide_glyphs=yes
 support_perl=yes
 codesets=all
 
@@ -111,6 +112,7 @@ AC_ARG_ENABLE(everything,
        support_8bitctrls=no
        support_iso14755=no
        support_styles=no
+       support_wide_glyphs=yes
        support_perl=no
        codesets=
     fi
@@ -185,6 +187,12 @@ AC_ARG_ENABLE(font-styles,
   [  --enable-font-styles    enable bold and italic support],
   [if test x$enableval = xyes -o x$enableval = xno; then
     support_styles=$enableval
+  fi])
+
+AC_ARG_ENABLE(wide-glyphs,
+  [ --enable-wide-glyphs     enable displaying of wide glyphs],
+  [if test x$enableval = xyes -o x$enableval = xno; then
+    support_wide_glyphs=$enableval
   fi])
 
 AC_ARG_ENABLE(pixbuf,
@@ -601,6 +609,9 @@ fi
 
 if test x$support_styles = xyes; then
   AC_DEFINE(ENABLE_STYLES, 1, Define if you want bold and italic support)
+fi
+if test x$support_wide_glyphs = xyes; then
+  AC_DEFINE(ENABLE_WIDE_GLYPHS, 1, Define if you want to display wide glyphs)
 fi
 if test x$support_iso14755 = xyes; then
   AC_DEFINE(ISO_14755, 1, Define if you want ISO 14755 extended support)

--- a/ptytty.m4
+++ b/ptytty.m4
@@ -1,0 +1,270 @@
+AC_DEFUN([PT_FIND_FILE],
+[AC_CACHE_CHECK(for a fallback location of $1, pt_cv_path_$1, [
+if test "$cross_compiling" != yes; then
+  for file in $3; do
+    if test -f "$file"; then
+      pt_cv_path_$1=$file
+      break
+    fi
+  done
+fi])
+if test x$pt_cv_path_$1 != x; then
+  AC_DEFINE_UNQUOTED($2, "$pt_cv_path_$1", Define to a fallback location of $1)
+elif test "$cross_compiling" = yes; then
+  AC_MSG_WARN(Define $2 in config.h manually)
+fi])
+
+AC_DEFUN([PTY_CHECK],
+[
+AC_CHECK_HEADERS( \
+  pty.h \
+  util.h \
+  libutil.h \
+  sys/ioctl.h \
+  stropts.h \
+)
+
+AC_CHECK_FUNCS( \
+  revoke \
+  _getpty \
+  getpt \
+  posix_openpt \
+  isastream \
+  setuid \
+  seteuid \
+  setreuid \
+  setresuid \
+)
+
+AC_MSG_CHECKING(for UNIX98 ptys)
+AC_LINK_IFELSE(
+  [AC_LANG_PROGRAM(
+     [[#include <stdlib.h>]],
+     [[grantpt(0);unlockpt(0);ptsname(0);]])],
+  [unix98_pty=yes
+   AC_DEFINE(UNIX98_PTY, 1, "")
+   AC_MSG_RESULT(yes)],
+  [AC_MSG_RESULT(no)])
+
+if test -z "$unix98_pty"; then
+  AC_SEARCH_LIBS(openpty, util, AC_DEFINE(HAVE_OPENPTY, 1, ""))
+fi
+])
+
+AC_DEFUN([UTMP_CHECK],
+[
+support_utmp=yes
+support_wtmp=yes
+support_lastlog=yes
+
+AC_ARG_ENABLE(utmp,
+  [AS_HELP_STRING([--enable-utmp],[enable utmp (utmpx) support])],
+  [if test x$enableval = xyes -o x$enableval = xno; then
+    support_utmp=$enableval
+  fi])
+
+AC_ARG_ENABLE(wtmp,
+  [AS_HELP_STRING([--enable-wtmp],[enable wtmp (wtmpx) support (requires --enable-utmp)])],
+  [if test x$enableval = xyes -o x$enableval = xno; then
+    support_wtmp=$enableval
+  fi])
+
+AC_ARG_ENABLE(lastlog,
+  [AS_HELP_STRING([--enable-lastlog],[enable lastlog support (requires --enable-utmp)])],
+  [if test x$enableval = xyes -o x$enableval = xno; then
+    support_lastlog=$enableval
+  fi])
+
+if test x$support_utmp = xyes; then
+  AC_DEFINE(UTMP_SUPPORT, 1, Define if you want to have utmp/utmpx support)
+fi
+if test x$support_wtmp = xyes; then
+  AC_DEFINE(WTMP_SUPPORT, 1, Define if you want to have wtmp support when utmp/utmpx is enabled)
+fi
+if test x$support_lastlog = xyes; then
+  AC_DEFINE(LASTLOG_SUPPORT, 1, Define if you want to have lastlog support when utmp/utmpx is enabled)
+fi
+
+AC_CHECK_FUNCS( \
+	updwtmp \
+	updwtmpx \
+	updlastlogx \
+)
+
+AC_CHECK_HEADERS(lastlog.h)
+
+case $host in
+   *-*-solaris*)
+      AC_DEFINE(__EXTENSIONS__, 1, Enable declarations in utmp.h on Solaris when the XPG4v2 namespace is active)
+      ;;
+esac
+
+dnl# --------------------------------------------------------------------------
+dnl# DO ALL UTMP AND WTMP CHECKING
+dnl# --------------------------------------------------------------------------
+dnl# check for host field in utmp structure
+
+dnl# --------------------------------------------
+AC_CHECK_HEADERS(utmp.h, [
+AC_CHECK_TYPES([struct utmp], [], [], [
+#include <sys/types.h>
+#include <utmp.h>
+])
+
+AC_CHECK_MEMBER([struct utmp.ut_host],
+[AC_DEFINE(HAVE_UTMP_HOST, 1, Define if struct utmp contains ut_host)], [], [
+#include <sys/types.h>
+#include <utmp.h>
+])
+
+AC_CHECK_MEMBER([struct utmp.ut_pid],
+[AC_DEFINE(HAVE_UTMP_PID, 1, Define if struct utmp contains ut_pid)], [], [
+#include <sys/types.h>
+#include <utmp.h>
+])
+]) dnl# AC_CHECK_HEADERS(utmp.h
+
+dnl# --------------------------------------------
+
+AC_CHECK_HEADERS(utmpx.h, [
+AC_CHECK_TYPES([struct utmpx], [], [], [
+#include <sys/types.h>
+#include <utmpx.h>
+])
+
+AC_CHECK_MEMBER([struct utmpx.ut_host],
+[AC_DEFINE(HAVE_UTMPX_HOST, 1, Define if struct utmpx contains ut_host)], [], [
+#include <sys/types.h>
+#include <utmpx.h>
+])
+]) dnl# AC_CHECK_HEADERS(utmpx.h
+
+dnl# --------------------------------------------------------------------------
+dnl# check for struct lastlog
+AC_CHECK_TYPES([struct lastlog], [], [], [
+#include <sys/types.h>
+#include <utmp.h>
+#ifdef HAVE_LASTLOG_H
+#include <lastlog.h>
+#endif
+])
+
+dnl# check for struct lastlogx
+AC_CHECK_TYPES([struct lastlogx], [], [], [
+#include <sys/types.h>
+#include <utmpx.h>
+#ifdef HAVE_LASTLOG_H
+#include <lastlog.h>
+#endif
+])
+
+dnl# --------------------------------------------------------------------------
+dnl# FIND FILES
+dnl# --------------------------------------------------------------------------
+
+dnl# find utmp
+PT_FIND_FILE([utmp], [PT_UTMP_FILE],
+["/var/run/utmp" "/var/adm/utmp" "/etc/utmp" "/usr/etc/utmp" "/usr/adm/utmp"])
+
+dnl# --------------------------------------------------------------------------
+
+dnl# find wtmp
+PT_FIND_FILE([wtmp], [PT_WTMP_FILE],
+["/var/log/wtmp" "/var/adm/wtmp" "/etc/wtmp" "/usr/etc/wtmp" "/usr/adm/wtmp"])
+dnl# --------------------------------------------------------------------------
+
+dnl# find wtmpx
+PT_FIND_FILE([wtmpx], [PT_WTMPX_FILE],
+["/var/log/wtmpx" "/var/adm/wtmpx"])
+dnl# --------------------------------------------------------------------------
+
+dnl# find lastlog
+PT_FIND_FILE([lastlog], [PT_LASTLOG_FILE],
+["/var/log/lastlog" "/var/adm/lastlog"])
+dnl# --------------------------------------------------------------------------
+
+dnl# find lastlogx
+PT_FIND_FILE([lastlogx], [PT_LASTLOGX_FILE],
+["/var/log/lastlogx" "/var/adm/lastlogx"])
+])
+
+AC_DEFUN([SCM_RIGHTS_CHECK],
+[
+AH_TEMPLATE([_XOPEN_SOURCE], [Enable declarations of msg_control and msg_controllen on Solaris])
+case $host in
+   *-*-solaris*)
+      AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+#if __STDC_VERSION__ >= 199901L
+error
+#endif
+]])],[AC_DEFINE(_XOPEN_SOURCE, 500)],[AC_DEFINE(_XOPEN_SOURCE, 600)])
+      AC_SEARCH_LIBS(sendmsg, socket)
+      ;;
+esac
+
+AC_CACHE_CHECK(for unix-compliant filehandle passing ability, pt_cv_can_pass_fds,
+[AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <stddef.h> // broken bsds (is that redundant?) need this
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+]], [[
+{
+  msghdr msg;
+  iovec iov;
+  char buf [100];
+  char data = 0;
+
+  iov.iov_base = &data;
+  iov.iov_len  = 1;
+
+  msg.msg_iov        = &iov;
+  msg.msg_iovlen     = 1;
+  msg.msg_control    = buf;
+  msg.msg_controllen = sizeof buf;
+
+  cmsghdr *cmsg = CMSG_FIRSTHDR (&msg);
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type  = SCM_RIGHTS;
+  cmsg->cmsg_len   = 100;
+
+  *(int *)CMSG_DATA (cmsg) = 5;
+
+  return sendmsg (3, &msg, 0);
+}
+]])],[pt_cv_can_pass_fds=yes],[pt_cv_can_pass_fds=no])])
+if test x$pt_cv_can_pass_fds = xyes; then
+   AC_DEFINE(HAVE_UNIX_FDPASS, 1, Define if sys/socket.h defines the necessary macros/functions for file handle passing)
+else
+   AC_MSG_ERROR([libptytty requires unix-compliant filehandle passing ability])
+fi
+])
+
+AC_DEFUN([TTY_GROUP_CHECK],
+[
+AC_CACHE_CHECK([for tty group], pt_cv_tty_group,
+[AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <grp.h>
+
+int main()
+{
+  struct stat st;
+  struct group *gr;
+  char *tty;
+  gr = getgrnam("tty");
+  tty = ttyname(0);
+  if (gr != 0
+      && tty != 0
+      && (stat(tty, &st)) == 0
+      && st.st_gid == gr->gr_gid)
+    return 0;
+  else
+    return 1;
+}]])],[pt_cv_tty_group=yes],[pt_cv_tty_group=no],[pt_cv_tty_group=no])])
+if test x$pt_cv_tty_group = xyes; then
+  AC_DEFINE(TTY_GID_SUPPORT, 1, "")
+fi])
+

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -236,7 +236,9 @@ rxvt_term::iso14755_51 (unicode_t ch, rend_t r, int x, int y, int y2)
       scr_overlay_set (9, y + 1, '=');
       scr_overlay_set (11, y + 1, ch, r);
 
+#if !ENABLE_WIDE_GLYPHS
       if (WCWIDTH (ch) >= 2)
+#endif
         scr_overlay_set (12, y + 1, NOCHAR, r);
     }
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -944,7 +944,62 @@ rxvt_term::scr_add_lines (const wchar_t *str, int len, int minlines)
 
       if (width != 0)
         {
-          rend_t rend = SET_FONT (rstyle, FONTSET (rstyle)->find_font (c));
+          rend_t rend;
+
+#if ENABLE_WIDE_GLYPHS
+          // Re-use previous font for space characters. This allows for better
+          // display of wider characters with regard to backtracking (which
+          // uses RS_SAME).
+          if (c != ' ')
+          {
+#endif
+            rend = SET_FONT (rstyle, FONTSET (rstyle)->find_font (c));
+#if ENABLE_WIDE_GLYPHS
+          } else {
+            // Code taken from ENABLE_COMBINING - might get refactored.
+            line_t* linep;
+            char32_t* tp;
+            rend_t* rp = nullptr;
+
+            if (screen.cur.col > 0)
+            {
+              linep = line;
+              tp = line->t + screen.cur.col - 1;
+              rp = line->r + screen.cur.col - 1;
+            }
+            else if (screen.cur.row > 0 && ROW(screen.cur.row - 1).is_longer())
+            {
+              linep = &ROW(screen.cur.row - 1);
+              tp = linep->t + ncol - 1;
+              rp = linep->r + ncol - 1;
+            }
+
+            if (rp)
+            {
+              // XXX: This font does not show up in iso-14755 mode for the
+              // space!?
+              if (*tp == NOCHAR)
+              {
+                while (*tp == NOCHAR && tp > linep->t)
+                {
+                  --tp;
+                  --rp;
+                }
+
+                // First try to find a precomposed character.
+                unicode_t n = rxvt_compose(*tp, c);
+                if (n == NOCHAR)
+                {
+                  n = rxvt_composite.compose(*tp, c);
+                }
+
+                *tp = n;
+                *rp = SET_FONT(*rp, FONTSET(*rp)->find_font(*tp));
+              }
+              rend = SET_FONT(rstyle, GET_FONT(*rp));
+            }
+          }
+#endif
 
           // if the character doesn't fit into the remaining columns...
           if (ecb_unlikely (screen.cur.col > ncol - width && ncol >= width))
@@ -2383,7 +2438,12 @@ rxvt_term::scr_refresh ()
                 text--, count++, xpixel -= fwidth;
 
               // force redraw after "careful" characters to avoid pixel droppings
-              for (int i = 0; srp[col + i] & RS_Careful && col + i < ncol - 1; i++)
+              for (int i = 0; srp[col + i] & RS_Careful && col + i < ncol - 1
+#if ENABLE_WIDE_GLYPHS
+                  // But not for spaces.
+                  && stp[col + i + 1] != ' '
+#endif
+                  ; ++i)
                 drp[col + i + 1] = srp[col + i + 1] ^ RS_redraw;
 
               // force redraw before "careful" characters to avoid pixel droppings

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -318,6 +318,9 @@ static const char optionsstring[] = "options: "
 #if ENABLE_STYLES
                                     "styles,"
 #endif
+#if ENABLE_WIDE_GLYPHS
+                                    "wide-glyphs,"
+#endif
 #if ENABLE_COMBINING
                                     "combining,"
 #endif


### PR DESCRIPTION
Fork of rxvt-unicode known in GitHub as [omaryoussef/rxvt-unicode](https://github.com/omaryouseef/rxvt-unicode) has a patch 9a0633a which adds support for wide glyphs. Include it in my own fork.