### PR TITLE
Add support for truecolor

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -1825,15 +1825,24 @@ void ecb_cold
 rxvt_term::update_fade_color (unsigned int idx, bool first_time)
 {
 #if OFF_FOCUS_FADING
-  if (get_setting(Rs_fade))
-    {
-      if (!first_time)
-        pix_colors_focused [idx].free (this);
+  rgba c;
 
-      rgba c;
-      pix_colors [Color_fade].get (c);
-      pix_colors_focused [idx].fade (this, atoi (get_setting(Rs_fade)), pix_colors_unfocused [idx], c);
-    }
+  if (!get_setting(Rs_fade))
+  {
+    return;
+  }
+  if (!first_time)
+  {
+    lookup_color(idx, pix_colors_focused).free(this);
+  }
+
+  lookup_color(Color_fade, pix_colors).get(c);
+  lookup_color(idx, pix_colors_focused).fade(
+    this,
+    std::atoi(get_setting(Rs_fade)),
+    lookup_color(idx, pix_colors_unfocused),
+    c
+  );
 #endif
 }
 
@@ -3397,20 +3406,40 @@ update:
 }
 
 void
-rxvt_term::process_color_seq (int report, int color, const char *str, char resp)
+rxvt_term::process_color_seq(int report,
+                             int color,
+                             const char* str,
+                             char resp)
 {
   if (str[0] == '?' && !str[1])
-    {
-      rgba c;
-      pix_colors_focused[color].get (c);
+  {
+    rgba c;
 
-      if (c.a != rgba::MAX_CC)
-        tt_printf ("\033]%d;rgba:%04x/%04x/%04x/%04x%c", report, c.r, c.g, c.b, c.a, resp);
-      else
-        tt_printf ("\033]%d;rgb:%04x/%04x/%04x%c", report, c.r, c.g, c.b, resp);
+    lookup_color(color, pix_colors_focused).get(c);
+    if (c.a != rgba::MAX_CC)
+    {
+      tt_printf(
+        "\033]%d;rgba:%04x/%04x/%04x/%04x%c",
+        report,
+        c.r,
+        c.g,
+        c.b,
+        c.a,
+        resp
+      );
+    } else {
+      tt_printf(
+        "\033]%d;rgb:%04x/%04x/%04x%c",
+        report,
+        c.r,
+        c.g,
+        c.b,
+        resp
+      );
     }
-  else
-    set_window_color (color, str);
+  } else {
+    set_window_color(color, str);
+  }
 }
 
 /*
@@ -3864,7 +3893,7 @@ rxvt_term::process_sgr_mode (unsigned int nargs, const int *arg)
 {
   unsigned int i;
   short rendset;
-  int rendstyle;
+  rend_t rendstyle;
 
   if (nargs == 0)
     {
@@ -3976,25 +4005,21 @@ rxvt_term::process_sgr_mode (unsigned int nargs, const int *arg)
               unsigned int idx;
 
               if (nargs > i + 2 && arg[i + 1] == 5)
-                {
-                  idx = minCOLOR + arg[i + 2];
-                  i += 2;
+              {
+                idx = minCOLOR + arg[i + 2];
+                i += 2;
 
-                  scr_color (idx, fgbg);
-                }
+                scr_color (idx, fgbg);
+              }
               else if (nargs > i + 4 && arg[i + 1] == 2)
-                {
-                  unsigned int r = arg[i + 2];
-                  unsigned int g = arg[i + 3];
-                  unsigned int b = arg[i + 4];
-                  unsigned int a = 0xff;
+              {
+                unsigned int r = arg[i + 2];
+                unsigned int g = arg[i + 3];
+                unsigned int b = arg[i + 4];
 
-                  idx = map_rgb24_color (r, g, b, a);
-
-                  i += 4;
-
-                  scr_color (idx, fgbg);
-                }
+                scr_color_rgb(r, g, b, fgbg);
+                i += 4;
+              }
             }
             break;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1067,11 +1067,9 @@ rxvt_term::get_colors ()
 
   for (i = 0; i < NRS_COLORS; i++)
   {
-    const char* name = get_setting(Rs_color + i);
-
-    if (name)
+    if (const char* name = get_setting(Rs_color + i))
     {
-      set_color(pix_colors[i], name);
+      set_color(lookup_color(i, pix_colors), name);
     }
   }
 
@@ -1082,20 +1080,38 @@ rxvt_term::get_colors ()
    * from the fvwm window manager.
    */
 #ifdef RXVT_SCROLLBAR
-  pix_colors [Color_scroll].fade (this, 50, pix_colors [Color_bottomShadow]);
+  lookup_color(Color_scroll, pix_colors).fade(
+    this,
+    50,
+    lookup_color(Color_bottomShadow, pix_colors)
+  );
 
   rgba cscroll;
-  pix_colors [Color_scroll].get (cscroll);
+  lookup_color(Color_scroll, pix_colors).get(cscroll);
 
   /* topShadowColor */
-  if (!pix_colors[Color_topShadow].set (this,
-                   rgba (
-                     std::min((int)rgba::MAX_CC, std::max<int>(cscroll.r / 5, cscroll.r) * 7 / 5),
-                     std::min((int)rgba::MAX_CC, std::max<int>(cscroll.g / 5, cscroll.g) * 7 / 5),
-                     std::min((int)rgba::MAX_CC, std::max<int>(cscroll.b / 5, cscroll.b) * 7 / 5),
-                     cscroll.a)
-                   ))
-    alias_color (Color_topShadow, Color_White);
+  if (!lookup_color(Color_topShadow, pix_colors).set(
+        this,
+        rgba(
+          std::min<int>(
+            rgba::MAX_CC,
+            std::max<int>(cscroll.r / 5, cscroll.r) * 7 / 5
+          ),
+          std::min<int>(
+            rgba::MAX_CC,
+            std::max<int>(cscroll.g / 5, cscroll.g) * 7 / 5
+          ),
+          std::min<int>(
+            rgba::MAX_CC,
+            std::max<int>(cscroll.b / 5, cscroll.b) * 7 / 5
+          ),
+          cscroll.a
+        )
+      )
+  )
+  {
+    alias_color(Color_topShadow, Color_White);
+  }
 #endif
 
 #ifdef OFF_FOCUS_FADING
@@ -1336,9 +1352,9 @@ rxvt_term::create_windows(const std::vector<std::string>& argv)
   window_calc (0, 0);
 
   /* sub-window placement & size in rxvt_term::resize_all_windows () */
-  attributes.background_pixel = pix_colors_focused [Color_border];
-  attributes.border_pixel     = pix_colors_focused [Color_border];
-  attributes.colormap         = cmap;
+  attributes.background_pixel = lookup_color(Color_border, pix_colors_focused);
+  attributes.border_pixel = lookup_color(Color_border, pix_colors_focused);
+  attributes.colormap = cmap;
 
   top = XCreateWindow (dpy, parent,
                        szHint.x, szHint.y,
@@ -1454,12 +1470,17 @@ rxvt_term::create_windows(const std::vector<std::string>& argv)
   TermWin_cursor = XCreateFontCursor (dpy, shape);
 
   /* the vt window */
-  vt = XCreateSimpleWindow (dpy, top,
-                            window_vt_x, window_vt_y,
-                            vt_width, vt_height,
-                            0,
-                            pix_colors_focused[Color_fg],
-                            pix_colors_focused[Color_bg]);
+  vt = ::XCreateSimpleWindow(
+    dpy,
+    top,
+    window_vt_x,
+    window_vt_y,
+    vt_width,
+    vt_height,
+    0,
+    lookup_color(Color_fg, pix_colors_focused),
+    lookup_color(Color_bg, pix_colors_focused)
+  );
 
   attributes.bit_gravity = NorthWestGravity;
   XChangeWindowAttributes (dpy, vt, CWBitGravity, &attributes);
@@ -1476,8 +1497,8 @@ rxvt_term::create_windows(const std::vector<std::string>& argv)
   vt_ev.start (display, vt);
 
   /* graphics context for the vt window */
-  gcvalue.foreground         = pix_colors[Color_fg];
-  gcvalue.background         = pix_colors[Color_bg];
+  gcvalue.foreground = lookup_color(Color_fg, pix_colors);
+  gcvalue.background = lookup_color(Color_bg, pix_colors);
   gcvalue.graphics_exposures = 0;
 
   gc = XCreateGC (dpy, vt,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,15 +253,19 @@ rxvt_term::~rxvt_term()
       if (parent)
         XDestroyWindow (dpy, parent);
 
-      for (int i = 0; i < TOTAL_COLORS; i++)
+      for (int i = 0; i < TOTAL_COLORS; ++i)
+      {
         if (ISSET_PIXCOLOR (i))
-          {
-            pix_colors_focused   [i].free (this);
+        {
+          lookup_color(i, pix_colors_focused).free(this);
 #if OFF_FOCUS_FADING
-            if (get_setting(Rs_fade))
-              pix_colors_unfocused [i].free (this);
-#endif
+          if (get_setting(Rs_fade))
+          {
+            lookup_color(i, pix_colors_unfocused).free(this);
           }
+#endif
+        }
+      }
 
       clear ();
 
@@ -947,8 +951,8 @@ rxvt_term::set_window_color (int idx, const char *color)
     }
   }
 
-  pix_colors_focused[idx].free(this);
-  set_color(pix_colors_focused[idx], color);
+  lookup_color(idx, pix_colors_focused).free(this);
+  set_color(lookup_color(idx, pix_colors_focused), color);
 
 done:
   /*TODO: handle Color_BD, scrollbar background, etc. */
@@ -965,12 +969,12 @@ rxvt_term::recolor_cursor ()
   XColor fg, bg;
 
   (ISSET_PIXCOLOR (Color_pointer_fg)
-     ? pix_colors_focused[Color_pointer_fg]
-     : pix_colors_focused[Color_fg]).get (fg);
+     ? lookup_color(Color_pointer_fg, pix_colors_focused)
+     : lookup_color(Color_fg, pix_colors_focused)).get(fg);
 
   (ISSET_PIXCOLOR (Color_pointer_bg)
-     ? pix_colors_focused[Color_pointer_bg]
-     : pix_colors_focused[Color_bg]).get (bg);
+     ? lookup_color(Color_pointer_bg, pix_colors_focused)
+     : lookup_color(Color_bg, pix_colors_focused)).get(bg);
 
   XRecolorCursor (dpy, TermWin_cursor, &fg, &bg);
 }
@@ -988,22 +992,26 @@ rxvt_term::get_colorfgbg ()
   char bstr[] = "default";
   char *env_colorfgbg;
 
-  for (i = Color_Black; i <= Color_White; i++)
-    if (pix_colors[Color_fg] == pix_colors[i])
-      {
-        sprintf (fstr, "%d", i - Color_Black);
-        break;
-      }
+  for (i = Color_Black; i <= Color_White; ++i)
+  {
+    if (lookup_color(Color_fg, pix_colors) == lookup_color(i, pix_colors))
+    {
+      std::sprintf(fstr, "%d", i - Color_Black);
+      break;
+    }
+  }
 
-  for (i = Color_Black; i <= Color_White; i++)
-    if (pix_colors[Color_bg] == pix_colors[i])
-      {
-        sprintf (bstr, "%d", i - Color_Black);
+  for (i = Color_Black; i <= Color_White; ++i)
+  {
+    if (lookup_color(Color_bg, pix_colors) == lookup_color(i, pix_colors))
+    {
+      std::sprintf(bstr, "%d", i - Color_Black);
 #if HAVE_IMG
-        xpmb = "default;";
+      xpmb = "default;";
 #endif
-        break;
-      }
+      break;
+    }
+  }
 
   env_colorfgbg = rxvt_malloc<char>(sizeof("COLORFGBG=default;default;bg"));
   sprintf (env_colorfgbg, "COLORFGBG=%s;%s%s", fstr, xpmb, bstr);
@@ -1027,9 +1035,9 @@ rxvt_term::alias_color(int dst, int src)
 {
   const char* color = get_setting(Rs_color + src);
 
-  pix_colors[dst].free(this);
+  lookup_color(dst, pix_colors).free(this);
   set_setting(Rs_color + dst, color);
-  pix_colors[dst].set(this, color);
+  lookup_color(dst, pix_colors).set(this, color);
 }
 
 #ifdef SMART_RESIZE
@@ -1179,12 +1187,11 @@ rxvt_term::set_widthheight (unsigned int newwidth, unsigned int newheight)
  * -                      X INPUT METHOD ROUTINES                     - *
  * -------------------------------------------------------------------- */
 #if USE_XIM
-
 void
-rxvt_term::im_set_color (unsigned long &fg, unsigned long &bg)
+rxvt_term::im_set_color(unsigned long& fg, unsigned long& bg)
 {
-  fg = pix_colors [Color_fg];
-  bg = pix_colors [Color_bg];
+  fg = lookup_color(Color_fg, pix_colors);
+  bg = lookup_color(Color_bg, pix_colors);
 }
 
 void

--- a/src/rxvtfont.cpp
+++ b/src/rxvtfont.cpp
@@ -228,17 +228,27 @@ rxvt_font::clear_rect (rxvt_drawable &d, int x, int y, int w, int h, int color) 
 
 # ifdef HAVE_IMG
       if (term->bg_img
-          && !term->pix_colors[color].is_opaque ()
+          && !term->lookup_color(color, term->pix_colors).is_opaque()
           && ((dst = XftDrawPicture (d))))
         {
           XClearArea (disp, d, x, y, w, h, false);
 
-          Picture solid_color_pict = XftDrawSrcPicture (d, &term->pix_colors[color].c);
+          Picture solid_color_pict = ::XftDrawSrcPicture(
+            d,
+            &term->lookup_color(color, term->pix_colors).c
+          );
           XRenderComposite (disp, PictOpOver, solid_color_pict, None, dst, 0, 0, 0, 0, x, y, w, h);
         }
       else
 # endif
-        XftDrawRect (d, &term->pix_colors[color].c, x, y, w, h);
+        ::XftDrawRect(
+          d,
+          &term->lookup_color(color, term->pix_colors).c,
+          x,
+          y,
+          w,
+          h
+        );
     }
 }
 
@@ -322,7 +332,11 @@ rxvt_font_default::draw (rxvt_drawable &d, int x, int y,
 
   clear_rect (d, x, y, term->fwidth * len, term->fheight, bg);
 
-  XSetForeground (disp, gc, term->pix_colors[fg]);
+  ::XSetForeground(
+    disp,
+    gc,
+    term->lookup_color(fg, term->pix_colors)
+  );
 
   while (len)
     {
@@ -1025,7 +1039,7 @@ rxvt_font_x11::draw (rxvt_drawable &d, int x, int y,
   int base = ascent; // sorry, incorrect: term->fbase;
 
   XGCValues v;
-  v.foreground = term->pix_colors[fg];
+  v.foreground = term->lookup_color(fg, term->pix_colors);
   v.font = f->fid;
 
   if (enc2b)
@@ -1034,7 +1048,7 @@ rxvt_font_x11::draw (rxvt_drawable &d, int x, int y,
 
       if (bg == Color_bg && !slow)
         {
-          v.background = term->pix_colors[bg];
+          v.background = term->lookup_color(bg, term->pix_colors);
           XChangeGC (disp, gc, GCForeground | GCBackground | GCFont, &v);
           XDrawImageString16 (disp, d, gc, x, y + base, xc, len);
         }
@@ -1066,7 +1080,7 @@ rxvt_font_x11::draw (rxvt_drawable &d, int x, int y,
 
       if (bg == Color_bg && !slow)
         {
-          v.background = term->pix_colors[bg];
+          v.background = term->lookup_color(bg, term->pix_colors);
           XChangeGC (disp, gc, GCForeground | GCBackground | GCFont, &v);
           XDrawImageString (disp, d, gc, x, y + base, xc, len);
         }
@@ -1377,7 +1391,7 @@ rxvt_font_xft::draw (rxvt_drawable &d, int x, int y,
 
           if (term->bg_img
               && (bg == Color_transparent || bg == Color_bg
-                  || (bg >= 0 && !term->pix_colors[bg].is_opaque () && ((dst = XftDrawPicture (d2))))))
+                  || (bg >= 0 && !term->lookup_color(bg, term->pix_colors).is_opaque() && ((dst = XftDrawPicture (d2))))))
             {
               int src_x = x, src_y = y;
 
@@ -1414,7 +1428,10 @@ rxvt_font_xft::draw (rxvt_drawable &d, int x, int y,
 
               if (dst)
                 {
-                  Picture solid_color_pict = XftDrawSrcPicture (d2, &term->pix_colors[bg].c);
+                  Picture solid_color_pict = ::XftDrawSrcPicture(
+                    d2,
+                    &term->lookup_color(bg, term->pix_colors).c
+                  );
 
                   // dst can only be set when bg >= 0
                   XRenderComposite (disp, PictOpOver, solid_color_pict, None, dst, 0, 0, 0, 0, 0, 0, w, h);
@@ -1422,9 +1439,25 @@ rxvt_font_xft::draw (rxvt_drawable &d, int x, int y,
             }
           else
 #endif
-            XftDrawRect (d2, &term->pix_colors[bg >= 0 ? bg : Color_bg].c, 0, 0, w, h);
+            ::XftDrawRect(
+              d2,
+              &term->lookup_color(
+                bg >= 0 ? bg : Color_bg,
+                term->pix_colors
+              ).c,
+              0,
+              0,
+              w,
+              h
+            );
 
-          XftDrawGlyphSpec (d2, &term->pix_colors[fg].c, f, enc, ep - enc);
+          ::XftDrawGlyphSpec(
+            d2,
+            &term->lookup_color(fg, term->pix_colors).c,
+            f,
+            enc,
+            ep - enc
+          );
           XCopyArea (disp, d2, d, gc, 0, 0, w, h, x, y);
         }
       else
@@ -1433,7 +1466,13 @@ rxvt_font_xft::draw (rxvt_drawable &d, int x, int y,
   else
     {
       clear_rect (d, x, y, w, h, bg);
-      XftDrawGlyphSpec (d, &term->pix_colors[fg].c, f, enc, ep - enc);
+      ::XftDrawGlyphSpec(
+        d,
+        &term->lookup_color(fg, term->pix_colors).c,
+        f,
+        enc,
+        ep - enc
+      );
     }
 }
 

--- a/src/rxvtfont.h
+++ b/src/rxvtfont.h
@@ -66,7 +66,7 @@ struct rxvt_fontset
   char *fontdesc;
 
   // must be power-of-two - 1, also has to match RS_fontMask in rxvt.h
-  enum { fontCount =   7 }; // 2 extra colors bits, 2 fewer fontcount bits
+  enum { fontCount =   7 }; // 36 extra colors bits, 4 fewer fontcount bits
 
   // index of first font in set
   enum { firstFont = 2 };

--- a/src/rxvtperl.xs
+++ b/src/rxvtperl.xs
@@ -2328,8 +2328,10 @@ rxvt_term::set_background (rxvt_img *img, bool border = false)
             img->reify ()
                ->replace (img);
 
-            img->convert_format (XRenderFindVisualFormat (THIS->dpy, THIS->visual), THIS->pix_colors [Color_bg])
-               ->replace (img);
+            img->convert_format(
+              XRenderFindVisualFormat(THIS->dpy, THIS->visual),
+              THIS->lookup_color(Color_bg, THIS->pix_colors)
+            )->replace(img);
 
             THIS->bg_img = img;
             THIS->bg_flags |= rxvt_term::BG_NEEDS_REFRESH;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -639,19 +639,76 @@ rxvt_term::scr_color (unsigned int color, int fgbg)
     rstyle = SET_BGCOLOR (rstyle, color);
 }
 
+static rxvt_color* scr_colors[1 << 24];
+
+void
+rxvt_term::scr_color_24(unsigned int color, int fgbg)
+{
+  color += TOTAL_COLORS;
+  if (fgbg == Color_fg)
+  {
+    rstyle = SET_FGCOLOR(rstyle, color);
+  } else {
+    rstyle = SET_BGCOLOR(rstyle, color);
+  }
+}
+
+void
+rxvt_term::scr_color_rgb(unsigned int r,
+                         unsigned int g,
+                         unsigned int b,
+                         int fgbg)
+{
+  const auto color = (r << 16) + (g << 8) + b;
+
+  scr_color_24(color, fgbg);
+}
+
+rxvt_color&
+rxvt_term::lookup_color(unsigned int color, rxvt_color* table)
+{
+  if (color >= TOTAL_COLORS)
+  {
+    color -= TOTAL_COLORS;
+    if (!scr_colors[color])
+    {
+      char name[1 + 2 * 3 + 1];
+
+      scr_colors[color] = new rxvt_color();
+      std::snprintf(
+        name,
+        sizeof(name),
+        "#%02x%02x%02x",
+        (color >> 16) & 0xff,
+        (color >> 8) & 0xff,
+        color & 0xff
+      );
+      scr_colors[color]->set(this, name);
+    }
+
+    return *scr_colors[color];
+  }
+
+  return table[color];
+}
+
 /* ------------------------------------------------------------------------- */
 /*
  * Change the rendition style for following text
  */
 void
-rxvt_term::scr_rendition (int set, int style)
+rxvt_term::scr_rendition(int set, rend_t style)
 {
   if (set)
+  {
     rstyle |= style;
+  }
   else if (style == ~RS_None)
+  {
     rstyle = DEFAULT_RSTYLE;
-  else
+  } else {
     rstyle &= ~style;
+  }
 }
 
 /* ------------------------------------------------------------------------- */
@@ -1454,16 +1511,16 @@ rxvt_term::scr_erase_screen (int mode)
       ren = rstyle & (RS_fgMask | RS_bgMask);
 
       if (mapped)
-        {
-          gcvalue.foreground = pix_colors[bgcolor_of (rstyle)];
-          XChangeGC (dpy, gc, GCForeground, &gcvalue);
-          XFillRectangle (dpy, vt, gc,
-                          0, Row2Pixel (row - view_start),
-                          (unsigned int)vt_width,
-                          (unsigned int)Height2Pixel (num));
-          gcvalue.foreground = pix_colors[Color_fg];
-          XChangeGC (dpy, gc, GCForeground, &gcvalue);
-        }
+      {
+        gcvalue.foreground = lookup_color(bgcolor_of(rstyle), pix_colors);
+        XChangeGC (dpy, gc, GCForeground, &gcvalue);
+        XFillRectangle (dpy, vt, gc,
+                        0, Row2Pixel (row - view_start),
+                        (unsigned int)vt_width,
+                        (unsigned int)Height2Pixel (num));
+        gcvalue.foreground = lookup_color(Color_fg, pix_colors);
+        XChangeGC (dpy, gc, GCForeground, &gcvalue);
+      }
     }
 
   for (; num--; row++)
@@ -1792,21 +1849,34 @@ rxvt_term::scr_rvideo_mode (bool on)
 
 #if OFF_FOCUS_FADING
       if (get_setting(Rs_fade))
-        {
-          std::swap(pix_colors_focused[Color_fg], pix_colors_focused[Color_bg]);
-          std::swap(pix_colors_unfocused[Color_fg], pix_colors_unfocused[Color_bg]);
-        }
+      {
+        std::swap(
+          lookup_color(Color_fg, pix_colors_focused),
+          lookup_color(Color_bg, pix_colors_focused)
+        );
+        std::swap(
+          lookup_color(Color_fg, pix_colors_unfocused),
+          lookup_color(Color_bg, pix_colors_unfocused)
+        );
+      }
       else
 #endif
-      std::swap(pix_colors[Color_fg], pix_colors[Color_bg]);
+      std::swap(
+        lookup_color(Color_fg, pix_colors),
+        lookup_color(Color_bg, pix_colors)
+      );
 #ifdef HAVE_IMG
       if (bg_img == 0)
 #endif
-          XSetWindowBackground (dpy, vt, pix_colors[Color_bg]);
+          ::XSetWindowBackground(
+            dpy,
+            vt,
+            lookup_color(Color_bg, pix_colors)
+          );
 
       XGCValues gcvalue;
-      gcvalue.foreground = pix_colors[Color_fg];
-      gcvalue.background = pix_colors[Color_bg];
+      gcvalue.foreground = lookup_color(Color_fg, pix_colors);
+      gcvalue.background = lookup_color(Color_bg, pix_colors);
       XChangeGC (dpy, gc, GCBackground | GCForeground, &gcvalue);
 
       scr_clear ();
@@ -2478,14 +2548,14 @@ rxvt_term::scr_refresh ()
             {
               if (showcursor && focus && row == screen.cur.row
                   && IN_RANGE_EXC (col, cur_col, cur_col + cursorwidth))
-                XSetForeground (dpy, gc, pix_colors[ccol1]);
+                XSetForeground (dpy, gc, lookup_color(ccol1, pix_colors));
               else
 #if ENABLE_FRILLS
               if (ISSET_PIXCOLOR (Color_underline))
-                XSetForeground (dpy, gc, pix_colors[Color_underline]);
+                XSetForeground (dpy, gc, lookup_color(Color_underline, pix_colors));
               else
 #endif
-                XSetForeground (dpy, gc, pix_colors[fore]);
+                XSetForeground (dpy, gc, lookup_color(fore, pix_colors));
 
               XDrawLine (dpy, vt, gc,
                          xpixel, ypixel + font->ascent + 1,
@@ -2505,7 +2575,7 @@ rxvt_term::scr_refresh ()
             scr_set_char_rend (ROW(screen.cur.row), cur_col, cur_rend);
           else if (oldcursor.row >= 0)
             {
-              XSetForeground (dpy, gc, pix_colors[ccol1]);
+              XSetForeground (dpy, gc, lookup_color(ccol1, pix_colors));
               if (cursor_type == 1)
                 XFillRectangle (dpy, vt, gc,
                                 Col2Pixel (cur_col),
@@ -2522,7 +2592,7 @@ rxvt_term::scr_refresh ()
         }
       else if (oldcursor.row >= 0)
         {
-          XSetForeground (dpy, gc, pix_colors[ccol1]);
+          XSetForeground (dpy, gc, lookup_color(ccol1, pix_colors));
 
           XDrawRectangle (dpy, vt, gc,
                           Col2Pixel (cur_col),
@@ -2591,15 +2661,15 @@ rxvt_term::scr_recolor (bool refresh)
       else
 # endif
         {
-          XSetWindowBackground (dpy, parent, pix_colors[Color_border]);
+          XSetWindowBackground (dpy, parent, lookup_color(Color_border, pix_colors));
           XSetWindowBackgroundPixmap (dpy, vt, bg_img->pm);
         }
     }
   else
 #endif
     {
-      XSetWindowBackground (dpy, parent, pix_colors[Color_border]);
-      XSetWindowBackground (dpy, vt, pix_colors[Color_bg]);
+      XSetWindowBackground (dpy, parent, lookup_color(Color_border, pix_colors));
+      XSetWindowBackground (dpy, vt, lookup_color(Color_bg, pix_colors));
     }
 
   XClearWindow (dpy, parent);
@@ -2609,7 +2679,7 @@ rxvt_term::scr_recolor (bool refresh)
       if (transparent)
         XSetWindowBackgroundPixmap (dpy, scrollBar.win, ParentRelative);
       else
-        XSetWindowBackground (dpy, scrollBar.win, pix_colors[scrollBar.color ()]);
+        XSetWindowBackground (dpy, scrollBar.win, lookup_color(scrollBar.color(), pix_colors));
       scrollBar.state = SB_STATE_IDLE;
       scrollBar.show (0);
     }

--- a/src/scrollbar-next.cpp
+++ b/src/scrollbar-next.cpp
@@ -154,20 +154,20 @@ scrollBar_t::init_next ()
 
   gcvalue.graphics_exposures = False;
 
-  gcvalue.foreground = term->pix_colors_focused[Color_Black];
+  gcvalue.foreground = term->lookup_color(Color_Black, term->pix_colors_focused);
   blackGC = XCreateGC (term->dpy, win,
                        GCForeground | GCGraphicsExposures, &gcvalue);
 
-  gcvalue.foreground = term->pix_colors_focused[Color_White];
+  gcvalue.foreground = term->lookup_color(Color_White, term->pix_colors_focused);
   whiteGC = XCreateGC (term->dpy, win,
                        GCForeground | GCGraphicsExposures, &gcvalue);
 
-  light = term->pix_colors_focused[Color_scroll];
+  light = term->lookup_color(Color_scroll, term->pix_colors_focused);
   gcvalue.foreground = light;
   grayGC = XCreateGC (term->dpy, win,
                       GCForeground | GCGraphicsExposures, &gcvalue);
 
-  dark = term->pix_colors_focused[Color_Grey25];
+  dark = term->lookup_color(Color_Grey25, term->pix_colors_focused);
   gcvalue.foreground = dark;
   darkGC = XCreateGC (term->dpy, win,
                      GCForeground | GCGraphicsExposures, &gcvalue);

--- a/src/scrollbar-plain.cpp
+++ b/src/scrollbar-plain.cpp
@@ -38,7 +38,7 @@ scrollBar_t::show_plain (int update)
       XGCValues gcvalue;
 
       init |= SB_STYLE_PLAIN;
-      gcvalue.foreground = term->pix_colors_focused[Color_scroll];
+      gcvalue.foreground = term->lookup_color(Color_scroll, term->pix_colors_focused);
 
       pscrollbarGC = XCreateGC (term->dpy, win, GCForeground, &gcvalue);
     }

--- a/src/scrollbar-rxvt.cpp
+++ b/src/scrollbar-rxvt.cpp
@@ -158,11 +158,11 @@ scrollBar_t::show_rxvt (int update)
 
       init |= SB_STYLE_RXVT;
 
-      gcvalue.foreground = term->pix_colors[Color_topShadow];
+      gcvalue.foreground = term->lookup_color(Color_topShadow, term->pix_colors);
       topShadowGC = XCreateGC (term->dpy, term->vt, GCForeground, &gcvalue);
-      gcvalue.foreground = term->pix_colors[Color_bottomShadow];
+      gcvalue.foreground = term->lookup_color(Color_bottomShadow, term->pix_colors);
       botShadowGC = XCreateGC (term->dpy, term->vt, GCForeground, &gcvalue);
-      gcvalue.foreground = term->pix_colors[ (term->depth <= 2 ? Color_fg : Color_scroll)];
+      gcvalue.foreground = term->lookup_color(term->depth <= 2 ? Color_fg : Color_scroll, term->pix_colors);
       scrollbarGC = XCreateGC (term->dpy, term->vt, GCForeground, &gcvalue);
     }
   else

--- a/src/scrollbar-xterm.cpp
+++ b/src/scrollbar-xterm.cpp
@@ -49,13 +49,13 @@ scrollBar_t::show_xterm (int update)
         rxvt_fatal ("can't create bitmap\n");
 
       gcvalue.fill_style = FillOpaqueStippled;
-      gcvalue.foreground = term->pix_colors_focused[Color_scroll];
-      gcvalue.background = term->pix_colors_focused[Color_bg];
+      gcvalue.foreground = term->lookup_color(Color_scroll, term->pix_colors_focused);
+      gcvalue.background = term->lookup_color(Color_bg, term->pix_colors_focused);
 
       xscrollbarGC = XCreateGC (term->dpy, win,
                                 GCForeground | GCBackground
                                 | GCFillStyle | GCStipple, &gcvalue);
-      gcvalue.foreground = term->pix_colors_focused[Color_border];
+      gcvalue.foreground = term->lookup_color(Color_border, term->pix_colors_focused);
       ShadowGC = XCreateGC (term->dpy, win, GCForeground, &gcvalue);
     }
 

--- a/src/scrollbar.cpp
+++ b/src/scrollbar.cpp
@@ -66,14 +66,17 @@ scrollBar_t::resize ()
   if (!win)
     {
       /* create the scrollbar window */
-      win = XCreateSimpleWindow (term->dpy,
-                                 term->parent,
-                                 window_sb_x, 0,
-                                 total_width (),
-                                 term->szHint.height,
-                                 0,
-                                 term->pix_colors[Color_fg],
-                                 term->pix_colors[color ()]);
+      win = ::XCreateSimpleWindow(
+        term->dpy,
+        term->parent,
+        window_sb_x,
+        0,
+        total_width(),
+        term->szHint.height,
+        0,
+        term->lookup_color(Color_fg, term->pix_colors),
+        term->lookup_color(color(), term->pix_colors)
+      );
       XDefineCursor (term->dpy, win, leftptr_cursor);
 
       XSelectInput (term->dpy, win,


### PR DESCRIPTION
Fork of rxvt-unicode, known as [da-x/rxvt-unicode](https://github.com/da-x/rxvt-unicode) implements proper truecolor support in commit dc9a4665. This is adaptation of that.